### PR TITLE
Align search engine with Lucene implementation and bump meilisearch-java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation platform('run.halo.tools.platform:plugin:2.21.0')
     compileOnly 'run.halo.app:api'
 
-    implementation('com.meilisearch.sdk:meilisearch-java:0.15.0') {
+    implementation('com.meilisearch.sdk:meilisearch-java:0.20.1') {
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
     }
 

--- a/src/main/java/run/halo/meilisearch/MeilisearchSearchEngine.java
+++ b/src/main/java/run/halo/meilisearch/MeilisearchSearchEngine.java
@@ -6,11 +6,13 @@ import com.meilisearch.sdk.Config;
 import com.meilisearch.sdk.Index;
 import com.meilisearch.sdk.SearchRequest;
 import com.meilisearch.sdk.exceptions.MeilisearchException;
+import com.meilisearch.sdk.model.SearchResult;
 import com.meilisearch.sdk.model.Searchable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.stream.Streams;
 import org.springframework.beans.factory.DisposableBean;
@@ -160,30 +162,80 @@ public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
             return new run.halo.app.search.SearchResult();
         }
 
-        StringJoiner filter = new StringJoiner(" AND ");
-        filter.add("recycled = false");
-        filter.add("exposed = true");
-        filter.add("published = true");
+        var filter = new StringJoiner(" AND ");
 
-        SearchRequest searchRequest = SearchRequest.builder()
+        var filterRecycled = searchOption.getFilterRecycled();
+        if (filterRecycled != null) {
+            filter.add("recycled = " + filterRecycled);
+        }
+
+        var filterExposed = searchOption.getFilterExposed();
+        if (filterExposed != null) {
+            filter.add("exposed = " + filterExposed);
+        }
+
+        var filterPublished = searchOption.getFilterPublished();
+        if (filterPublished != null) {
+            filter.add("published = " + filterPublished);
+        }
+
+        var includeTypes = searchOption.getIncludeTypes();
+        if (includeTypes != null && !includeTypes.isEmpty()) {
+            var typeFilter = includeTypes.stream()
+                .distinct()
+                .map(type -> "type = '" + type + "'")
+                .collect(Collectors.joining(" OR "));
+            filter.add("(" + typeFilter + ")");
+        }
+
+        var includeOwnerNames = searchOption.getIncludeOwnerNames();
+        if (includeOwnerNames != null && !includeOwnerNames.isEmpty()) {
+            var ownerFilter = includeOwnerNames.stream()
+                .distinct()
+                .map(owner -> "ownerName = '" + owner + "'")
+                .collect(Collectors.joining(" OR "));
+            filter.add("(" + ownerFilter + ")");
+        }
+
+        var includeTagNames = searchOption.getIncludeTagNames();
+        if (includeTagNames != null && !includeTagNames.isEmpty()) {
+            var tagFilter = includeTagNames.stream()
+                .distinct()
+                .map(tag -> "tags = '" + tag + "'")
+                .collect(Collectors.joining(" AND "));
+            filter.add("(" + tagFilter + ")");
+        }
+
+        var includeCategoryNames = searchOption.getIncludeCategoryNames();
+        if (includeCategoryNames != null && !includeCategoryNames.isEmpty()) {
+            var categoryFilter = includeCategoryNames.stream()
+                .distinct()
+                .map(category -> "categories = '" + category + "'")
+                .collect(Collectors.joining(" AND "));
+            filter.add("(" + categoryFilter + ")");
+        }
+
+        var searchRequestBuilder = SearchRequest.builder()
             .q(searchOption.getKeyword())
             .limit(searchOption.getLimit())
-            .filter(new String[]{filter.toString()})
             .attributesToSearchOn(SEARCH_ATTRIBUTES)
             .attributesToHighlight(HIGHLIGHT_ATTRIBUTES)
             .highlightPreTag(searchOption.getHighlightPreTag())
             .highlightPostTag(searchOption.getHighlightPostTag())
             .attributesToCrop(CROP_ATTRIBUTES)
             .cropLength(200)
-            .cropMarker("")
-            .build();
+            .cropMarker("");
+
+        if (filter.length() > 0) {
+            searchRequestBuilder.filter(new String[]{filter.toString()});
+        }
 
         try {
-            Searchable meilisearchResult = this.index.search(searchRequest);
+            Searchable meilisearchResult = this.index.search(searchRequestBuilder.build());
 
             var result = new run.halo.app.search.SearchResult();
             result.setLimit(searchOption.getLimit());
-            result.setTotal((long) meilisearchResult.getHits().size());
+            result.setTotal((long) ((SearchResult) meilisearchResult).getEstimatedTotalHits());
             result.setKeyword(searchOption.getKeyword());
             result.setProcessingTimeMillis(meilisearchResult.getProcessingTimeMs());
             result.setHits(convertHits(meilisearchResult.getHits()));


### PR DESCRIPTION
## Summary

This PR aligns `MeilisearchSearchEngine` with the behavior of Halo's built-in `LuceneSearchEngine` and bumps the Meilisearch Java SDK to the latest version.

### Changes

1. **Bump meilisearch-java from 0.15.0 to 0.20.1**
   - Includes a security fix for `deleteDocument` (no longer deletes all documents when given an empty/null identifier)
   - Adds compatibility with newer Meilisearch server features

2. **Fix total hits calculation**
   - Previously returned `getHits().size()` which is capped by `limit`
   - Now uses `getEstimatedTotalHits()` to return the actual total match count

3. **Support nullable filter fields**
   - `filterExposed`, `filterRecycled`, `filterPublished` are now optional instead of hardcoded
   - Matches Lucene's behavior where null means "no filter"

4. **Add missing filter supports**
   - `includeTypes` - filter by document types (OR logic)
   - `includeOwnerNames` - filter by owner names (OR logic)
   - `includeTagNames` - filter by tag names (AND logic)
   - `includeCategoryNames` - filter by category names (AND logic)

## Test plan

- [x] Compile passes (`./gradlew compileJava`)
- [x] Search with various filter combinations
- [x] Verify total hits reflect actual match count, not limited results

```release-note
None
```