### PR TITLE
Fix Meilisearch indexing recovery and document identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,79 @@
+# AGENTS.md
+
+## Project Overview
+
+- This repository is a Halo plugin that integrates Meilisearch as a search engine.
+- Backend Java code lives in `src/main/java/run/halo/meilisearch`.
+- Plugin metadata and Halo resources live in `src/main/resources`, especially `plugin.yaml` and `extensions/`.
+- The Console UI lives in `ui/` and is bundled into the plugin during Gradle builds.
+- Generated OpenAPI client code lives in `ui/src/api/generated`; do not hand-edit it unless the task is specifically about generated output.
+
+## Environment
+
+- Use Java 21 and the Gradle wrapper.
+- Use Node.js 24 and pnpm 10 for the UI, matching `.github/workflows/ci.yaml`.
+- Compatibility is declared in multiple places: `build.gradle`, `src/main/resources/plugin.yaml`, and `ui/package.json`. Keep these changes intentional and aligned when updating Halo versions.
+
+## Setup And Build Commands
+
+- Full build: `./gradlew build`
+- Backend tests only: `./gradlew test`
+- UI unit tests through Gradle: `./gradlew :ui:pnpmCheck`
+- UI install: `pnpm --dir ui install`
+- UI build and type-check: `pnpm --dir ui build`
+- UI type-check only: `pnpm --dir ui type-check`
+- UI lint and format: `pnpm --dir ui lint` and `pnpm --dir ui prettier`
+
+For local Halo plugin development:
+
+- Start Halo with the plugin: `./gradlew haloServer`
+- Reload plugin changes: `./gradlew reload`
+- Watch and rebuild during development: `./gradlew watch`
+- Regenerate the UI API client after backend endpoint changes: `./gradlew generateApiClient`
+
+## Backend Guidelines
+
+- Follow existing Spring and Halo plugin patterns: constructor injection, small components, and explicit logging around external Meilisearch calls.
+- Keep plugin settings centered on `MeilisearchProperties`, `settings.yaml`, and the `meilisearch-engine-config` ConfigMap.
+- Treat Meilisearch as an external dependency that can be unavailable. Preserve tolerant behavior where search/index operations log failures without breaking Halo core flows.
+- Do not log or expose `masterKey` values.
+- When adding or changing `CustomEndpoint` routes, update OpenAPI metadata and regenerate `ui/src/api/generated`.
+- Prefer Halo plugin APIs and local project patterns over ad hoc infrastructure.
+
+## Frontend Guidelines
+
+- Use Vue 3 with `<script setup lang="ts">`.
+- Use `@halo-dev/components`, `@halo-dev/ui-shared`, Vue Query, and the generated API client before introducing new UI or request abstractions.
+- Keep Console-facing copy in Chinese unless the surrounding UI is already English.
+- Preserve the current UnoCSS usage, including the `:uno:` prefix used in existing Vue templates.
+- Use icons from `unplugin-icons` when adding icon UI.
+- Do not edit `ui/src/api/generated` by hand; regenerate it from backend OpenAPI changes.
+
+## Testing Expectations
+
+- Run the smallest relevant check while iterating, then run broader checks before handing off meaningful code changes.
+- For backend behavior, add or update JUnit tests under `src/test/java`.
+- For UI logic, add or update Vitest/component tests when the change has non-trivial behavior.
+- `./gradlew :ui:pnpmCheck` currently runs UI unit tests only; run `pnpm --dir ui type-check` or `pnpm --dir ui build` for TypeScript validation.
+- For docs-only changes, at least inspect the diff and run `git diff --check`.
+
+## Documentation Lookup
+
+- Use Context7 MCP to fetch current documentation whenever the task asks about a library, framework, SDK, API, CLI tool, or cloud service.
+- Start with `resolve-library-id` unless the user provides an exact `/org/project` library ID.
+- Pick the best matching library ID by exact name, relevance, snippet count, source reputation, and benchmark score.
+- Query docs with the full user question, then answer using the fetched docs.
+- Do not use Context7 for ordinary refactors, scripts from scratch, business logic debugging, code review, or general programming concepts.
+
+## Security And Data Handling
+
+- Never commit real Meilisearch master keys, Halo tokens, local URLs with credentials, or generated local config files.
+- Keep examples and README snippets on placeholders such as `<your-super-secret-master-key-here>`.
+- Be careful with search filters and user-controlled values that become Meilisearch filter expressions.
+- Avoid destructive index operations unless the user explicitly asks for them or the existing UI flow clearly confirms the action.
+
+## Pull Request Notes
+
+- Keep changes scoped to the task and avoid unrelated formatting churn.
+- Mention the checks you ran in the final response or PR body.
+- If changing runtime compatibility, document the affected Halo, Java, Node, pnpm, or Meilisearch version assumptions.

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform('run.halo.tools.platform:plugin:2.21.0')
+    implementation platform('run.halo.tools.platform:plugin:2.22.0')
     compileOnly 'run.halo.app:api'
 
     implementation('com.meilisearch.sdk:meilisearch-java:0.20.1') {
@@ -50,7 +50,7 @@ tasks.named('classes') {
 }
 
 halo {
-    version = '2.21'
+    version = '2.22'
 }
 
 haloPlugin {

--- a/src/main/java/run/halo/meilisearch/ConfigListener.java
+++ b/src/main/java/run/halo/meilisearch/ConfigListener.java
@@ -19,6 +19,8 @@ import run.halo.app.infra.utils.JsonUtils;
 @Component
 public class ConfigListener implements Reconciler<Reconciler.Request> {
 
+    static final String CONFIG_MAP_NAME = "meilisearch-engine-config";
+
     private final ExtensionClient client;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -29,6 +31,10 @@ public class ConfigListener implements Reconciler<Reconciler.Request> {
 
     @Override
     public Result reconcile(Request request) {
+        if (!CONFIG_MAP_NAME.equals(request.name())) {
+            return Result.doNotRetry();
+        }
+
         return client.fetch(ConfigMap.class, request.name())
             .map(configMap -> {
                 if (ExtensionUtil.isDeleted(configMap)) {
@@ -36,11 +42,15 @@ public class ConfigListener implements Reconciler<Reconciler.Request> {
                 }
 
                 var data = configMap.getData();
-                if (data.containsKey("basic")) {
+                if (data != null && data.containsKey("basic")) {
                     var json = data.get("basic");
                     try {
                         var meilisearchProperties =
                             JsonUtils.mapper().readValue(json, MeilisearchProperties.class);
+                        if (!hasUsableConfiguration(meilisearchProperties)) {
+                            log.debug("Ignoring incomplete Meilisearch configuration");
+                            return Result.doNotRetry();
+                        }
                         eventPublisher.publishEvent(
                             new ConfigUpdatedEvent(this, meilisearchProperties)
                         );
@@ -53,16 +63,24 @@ public class ConfigListener implements Reconciler<Reconciler.Request> {
             .orElseGet(Result::doNotRetry);
     }
 
+    private boolean hasUsableConfiguration(MeilisearchProperties properties) {
+        return properties != null
+            && properties.getHost() != null
+            && !properties.getHost().isBlank()
+            && properties.getIndexName() != null
+            && !properties.getIndexName().isBlank();
+    }
+
     @Override
     public Controller setupWith(ControllerBuilder builder) {
         var configMap = new ConfigMap();
         var matcher = DefaultExtensionMatcher.builder(client, configMap.groupVersionKind())
             .fieldSelector(FieldSelector.of(
-                QueryFactory.equal("metadata.name", "meilisearch-engine-config")))
+                QueryFactory.equal("metadata.name", CONFIG_MAP_NAME)))
             .build();
         return builder
             .extension(configMap)
-            .syncAllOnStart(false)
+            .syncAllOnStart(true)
             .onAddMatcher(matcher)
             .onDeleteMatcher(matcher)
             .onUpdateMatcher(matcher)

--- a/src/main/java/run/halo/meilisearch/MeilisearchConsoleEndpoint.java
+++ b/src/main/java/run/halo/meilisearch/MeilisearchConsoleEndpoint.java
@@ -2,9 +2,6 @@ package run.halo.meilisearch;
 
 import static org.springdoc.core.fn.builders.apiresponse.Builder.responseBuilder;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.meilisearch.sdk.Client;
-import com.meilisearch.sdk.Config;
 import com.meilisearch.sdk.exceptions.MeilisearchException;
 import com.meilisearch.sdk.model.IndexStats;
 import lombok.RequiredArgsConstructor;
@@ -18,16 +15,16 @@ import org.springframework.web.reactive.function.server.ServerResponse;
 import org.springframework.web.server.ServerErrorException;
 import org.springframework.web.server.ServerWebInputException;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import run.halo.app.core.extension.endpoint.CustomEndpoint;
 import run.halo.app.extension.GroupVersion;
-import run.halo.app.plugin.ReactiveSettingFetcher;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class MeilisearchConsoleEndpoint implements CustomEndpoint {
 
-    private final ReactiveSettingFetcher reactiveSettingFetcher;
+    private final MeilisearchSearchEngine searchEngine;
 
     @Override
     public RouterFunction<ServerResponse> endpoint() {
@@ -44,29 +41,22 @@ public class MeilisearchConsoleEndpoint implements CustomEndpoint {
     }
 
     private Mono<ServerResponse> getStats(ServerRequest request) {
-        return reactiveSettingFetcher.fetch("basic", MeilisearchProperties.class)
-            .flatMap(properties -> {
-                var host = properties.getHost();
-                var indexName = properties.getIndexName();
-
-                if (host == null || host.isEmpty() || indexName == null || indexName.isEmpty()) {
-                    return Mono.error(new ServerWebInputException("Meilisearch host or index name is not configured"));
+        return Mono.fromCallable(searchEngine::getStats)
+            .subscribeOn(Schedulers.boundedElastic())
+            .flatMap(stats -> ServerResponse.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(stats))
+            .onErrorResume(e -> {
+                if (e instanceof IllegalStateException) {
+                    return Mono.error(new ServerWebInputException(e.getMessage()));
                 }
-
-                return Mono.fromCallable(() -> getMeilisearchStats(properties))
-                    .flatMap(stats -> ServerResponse.ok()
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .bodyValue(stats))
-                    .onErrorResume(MeilisearchException.class, e -> Mono.error(new ServerErrorException("Failed to get Meilisearch stats", e)))
-                    .onErrorResume(Exception.class, e -> Mono.error(new ServerErrorException("Unexpected error: " + e.getMessage(), e)));
-            })
-            .onErrorResume(e -> Mono.error(new ServerWebInputException("Failed to fetch Meilisearch configuration")));
-    }
-
-    private IndexStats getMeilisearchStats(MeilisearchProperties properties) throws MeilisearchException {
-        var client = new Client(new Config(properties.getHost(), properties.getMasterKey()));
-        var index = client.index(properties.getIndexName());
-        return index.getStats();
+                if (e instanceof MeilisearchException) {
+                    return Mono.error(new ServerErrorException("Failed to get Meilisearch stats",
+                        e));
+                }
+                return Mono.error(new ServerErrorException("Unexpected error: " + e.getMessage(),
+                    e));
+            });
     }
 
     @Override

--- a/src/main/java/run/halo/meilisearch/MeilisearchSearchEngine.java
+++ b/src/main/java/run/halo/meilisearch/MeilisearchSearchEngine.java
@@ -7,6 +7,7 @@ import com.meilisearch.sdk.Config;
 import com.meilisearch.sdk.Index;
 import com.meilisearch.sdk.SearchRequest;
 import com.meilisearch.sdk.exceptions.MeilisearchException;
+import com.meilisearch.sdk.model.IndexStats;
 import com.meilisearch.sdk.model.SearchResult;
 import com.meilisearch.sdk.model.Searchable;
 import com.meilisearch.sdk.model.Settings;
@@ -292,13 +293,40 @@ public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
                 + operation);
         }
         var taskUid = taskInfo.getTaskUid();
-        this.meilisearchClient.waitForTask(taskUid);
-
-        var task = this.meilisearchClient.getTask(taskUid);
+        var task = waitForClientTaskFinished(taskUid);
         if (task == null || task.getStatus() != TaskStatus.SUCCEEDED) {
             throw new MeilisearchException("Meilisearch task failed while trying to "
                 + operation + ": " + describeTask(task));
         }
+    }
+
+    private Task waitForClientTaskFinished(int taskUid) throws MeilisearchException {
+        var startedAt = System.currentTimeMillis();
+        while (true) {
+            var task = this.meilisearchClient.getTask(taskUid);
+            if (isTaskFinished(task)) {
+                return task;
+            }
+            if (System.currentTimeMillis() - startedAt >= TASK_WAIT_TIMEOUT_MS) {
+                throw new MeilisearchException("Timed out while waiting for Meilisearch task "
+                    + taskUid);
+            }
+            try {
+                Thread.sleep(TASK_WAIT_INTERVAL_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new MeilisearchException("Interrupted while waiting for Meilisearch task "
+                    + taskUid);
+            }
+        }
+    }
+
+    private boolean isTaskFinished(Task task) {
+        if (task == null) {
+            return true;
+        }
+        var status = task.getStatus();
+        return status != TaskStatus.ENQUEUED && status != TaskStatus.PROCESSING;
     }
 
     private String describeTask(Task task) {
@@ -387,6 +415,14 @@ public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
     @Override
     public boolean available() {
         return available;
+    }
+
+    IndexStats getStats() throws MeilisearchException {
+        var currentIndex = this.index;
+        if (!available || currentIndex == null) {
+            throw new IllegalStateException("Meilisearch is not available");
+        }
+        return currentIndex.getStats();
     }
 
     private HaloDocument cleanDocument(HaloDocument document) {

--- a/src/main/java/run/halo/meilisearch/MeilisearchSearchEngine.java
+++ b/src/main/java/run/halo/meilisearch/MeilisearchSearchEngine.java
@@ -8,76 +8,330 @@ import com.meilisearch.sdk.SearchRequest;
 import com.meilisearch.sdk.exceptions.MeilisearchException;
 import com.meilisearch.sdk.model.SearchResult;
 import com.meilisearch.sdk.model.Searchable;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.StringJoiner;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.stream.Streams;
 import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.context.ApplicationListener;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import run.halo.app.extension.ConfigMap;
 import run.halo.app.extension.ExtensionClient;
 import run.halo.app.infra.utils.JsonUtils;
+import run.halo.app.plugin.event.PluginStartedEvent;
 import run.halo.app.search.HaloDocument;
 import run.halo.app.search.SearchEngine;
 import run.halo.app.search.SearchOption;
+import run.halo.app.search.event.HaloDocumentRebuildRequestEvent;
 
 @Slf4j
 @Component
 public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
-    InitializingBean, ApplicationListener<ConfigUpdatedEvent> {
+    InitializingBean {
 
     private static final String[] HIGHLIGHT_ATTRIBUTES =
         {"title", "description", "content", "categories", "tags"};
     private static final String[] SEARCH_ATTRIBUTES = {"title", "description", "content"};
     private static final String[] CROP_ATTRIBUTES = {"description", "content"};
+    private static final String[] FILTERABLE_ATTRIBUTES = {
+        "published", "recycled", "exposed", "type", "ownerName", "categories", "tags"
+    };
+    private static final String[] DISPLAYED_ATTRIBUTES = {
+        "id", "metadataName", "title", "annotations", "description", "categories", "tags",
+        "published", "recycled", "exposed", "ownerName", "creationTimestamp",
+        "updateTimestamp", "permalink", "type", "content"
+    };
+    private static final String DOCUMENT_PRIMARY_KEY = "id";
+    private static final int TASK_WAIT_TIMEOUT_MS = 60_000;
+    private static final int TASK_WAIT_INTERVAL_MS = 100;
+    private static final int RETRY_DELAY_SECONDS = 5;
+    private static final int MAX_RETRY_ATTEMPTS = 24;
 
     private final ExtensionClient client;
+    private final ApplicationEventPublisher eventPublisher;
+    private final ClientFactory clientFactory;
+    private final ScheduledExecutorService retryExecutor;
 
     private Client meilisearchClient;
     private Index index;
     private volatile boolean available = false;
+    private volatile boolean disposed = false;
+    private ScheduledFuture<?> retryFuture;
+    private int retryAttempts = 0;
+    private volatile String currentHost;
+    private volatile String currentApiKey;
+    private volatile String currentIndexName;
+    private volatile String pendingHost;
+    private volatile String pendingApiKey;
+    private volatile String pendingIndexName;
+    private boolean rebuildOnNextSuccessfulInitialization = false;
+    private boolean pluginStarted = false;
+    private boolean rebuildPending = false;
 
-    public MeilisearchSearchEngine(ExtensionClient client) {
-        this.client = client;
+    @Autowired
+    public MeilisearchSearchEngine(ExtensionClient client,
+        ApplicationEventPublisher eventPublisher) {
+        this(client, eventPublisher, config -> new Client(config),
+            Executors.newSingleThreadScheduledExecutor(runnable -> {
+                var thread = new Thread(runnable, "meilisearch-initialization-retry");
+                thread.setDaemon(true);
+                return thread;
+            }));
     }
 
-    private void refresh(String host, String apiKey, String indexName) {
-        if (this.available) {
-            try {
-                this.destroy();
-            } catch (Exception e) {
-                log.warn("Failed to destroy MeilisearchSearchEngine during refreshing config", e);
-            }
+    MeilisearchSearchEngine(ExtensionClient client,
+        ApplicationEventPublisher eventPublisher,
+        ClientFactory clientFactory,
+        ScheduledExecutorService retryExecutor) {
+        this.client = client;
+        this.eventPublisher = eventPublisher;
+        this.clientFactory = clientFactory;
+        this.retryExecutor = retryExecutor;
+    }
+
+    private synchronized void refresh(String host, String apiKey, String indexName) {
+        if (this.disposed) {
+            return;
+        }
+        if (!hasUsableConfiguration(host, indexName)) {
+            logIncompleteConfiguration(host, indexName);
+            return;
+        }
+        cancelScheduledRetry();
+        this.retryAttempts = 0;
+        refresh(host, apiKey, indexName, true);
+    }
+
+    private void refresh(String host, String apiKey, String indexName, boolean scheduleRetry) {
+        if (this.available
+            && Objects.equals(this.currentHost, host)
+            && Objects.equals(this.currentApiKey, apiKey)
+            && Objects.equals(this.currentIndexName, indexName)) {
+            return;
         }
 
+        resetState();
+
         try {
-            this.meilisearchClient = new Client(new Config(host, apiKey));
+            this.meilisearchClient = clientFactory.create(new Config(host, apiKey));
             this.index = this.meilisearchClient.index(indexName);
 
-            this.index.updateSearchableAttributesSettings(SEARCH_ATTRIBUTES);
-            this.index.updateFilterableAttributesSettings(new String[]{
-                "published", "recycled", "exposed", "type", "categories", "tags"
-            });
-            this.index.updateDisplayedAttributesSettings(new String[]{
-                "id", "metadataName", "title", "annotations", "description", "categories", "tags",
-                "published", "recycled", "exposed", "ownerName", "creationTimestamp",
-                "updateTimestamp", "permalink", "type", "content"
-            });
+            ensureIndexPrimaryKey(indexName);
+            initializeIndexSettings();
 
+            var recoveredFromRetry = this.retryAttempts > 0;
+            var shouldRebuild = recoveredFromRetry || this.rebuildOnNextSuccessfulInitialization;
             this.available = true;
+            this.currentHost = host;
+            this.currentApiKey = apiKey;
+            this.currentIndexName = indexName;
+            this.retryAttempts = 0;
+            this.rebuildOnNextSuccessfulInitialization = false;
+            clearPendingConfig();
             log.info("Meilisearch client initialized successfully, index: {}", indexName);
+            if (shouldRebuild) {
+                requestRebuild();
+            }
         } catch (MeilisearchException e) {
             log.error("Failed to initialize Meilisearch client", e);
             this.available = false;
+            if (scheduleRetry) {
+                scheduleRetry(host, apiKey, indexName);
+            }
         } catch (Exception e) {
             log.error("Unexpected error during Meilisearch initialization", e);
             this.available = false;
+            if (scheduleRetry) {
+                scheduleRetry(host, apiKey, indexName);
+            }
         }
+    }
+
+    private boolean hasUsableConfiguration(String host, String indexName) {
+        return host != null && !host.isBlank()
+            && indexName != null && !indexName.isBlank();
+    }
+
+    private void logIncompleteConfiguration(String host, String indexName) {
+        if (host == null || host.isBlank()) {
+            log.warn("Meilisearch host is not configured");
+            return;
+        }
+        log.warn("Meilisearch index name is not configured");
+    }
+
+    private void requestRebuild() {
+        if (!this.pluginStarted) {
+            this.rebuildPending = true;
+            log.info("Deferring search index rebuild until Meilisearch plugin is fully started");
+            return;
+        }
+        this.rebuildPending = false;
+        publishRebuildRequest();
+    }
+
+    private void publishRebuildRequest() {
+        try {
+            log.info("Requesting search index rebuild after Meilisearch initialization recovery");
+            this.eventPublisher.publishEvent(new HaloDocumentRebuildRequestEvent(this));
+        } catch (Exception e) {
+            log.warn("Failed to publish search index rebuild request", e);
+        }
+    }
+
+    private void clearPendingConfig() {
+        this.pendingHost = null;
+        this.pendingApiKey = null;
+        this.pendingIndexName = null;
+    }
+
+    private void scheduleRetry(String host, String apiKey, String indexName) {
+        if (this.disposed) {
+            return;
+        }
+        if (this.retryAttempts >= MAX_RETRY_ATTEMPTS) {
+            log.warn("Meilisearch initialization retry limit reached, index: {}", indexName);
+            return;
+        }
+
+        this.retryAttempts++;
+        this.pendingHost = host;
+        this.pendingApiKey = apiKey;
+        this.pendingIndexName = indexName;
+        this.retryFuture = retryExecutor.schedule(() -> retry(host, apiKey, indexName),
+            RETRY_DELAY_SECONDS, TimeUnit.SECONDS);
+        log.info("Scheduled Meilisearch initialization retry {}/{} in {}s, index: {}",
+            this.retryAttempts, MAX_RETRY_ATTEMPTS, RETRY_DELAY_SECONDS, indexName);
+    }
+
+    private synchronized void retry(String host, String apiKey, String indexName) {
+        this.retryFuture = null;
+        if (this.disposed || !isPendingConfig(host, apiKey, indexName)) {
+            return;
+        }
+
+        log.info("Retrying Meilisearch initialization {}/{}, index: {}",
+            this.retryAttempts, MAX_RETRY_ATTEMPTS, indexName);
+        refresh(host, apiKey, indexName, true);
+    }
+
+    private boolean isPendingConfig(String host, String apiKey, String indexName) {
+        return Objects.equals(this.pendingHost, host)
+            && Objects.equals(this.pendingApiKey, apiKey)
+            && Objects.equals(this.pendingIndexName, indexName);
+    }
+
+    private void cancelScheduledRetry() {
+        if (this.retryFuture != null) {
+            this.retryFuture.cancel(false);
+            this.retryFuture = null;
+        }
+        clearPendingConfig();
+    }
+
+    private void resetState() {
+        this.available = false;
+        this.meilisearchClient = null;
+        this.index = null;
+    }
+
+    private void initializeIndexSettings() throws MeilisearchException {
+        updateIndexSettings();
+        validateIndexSettings();
+    }
+
+    private void updateIndexSettings() throws MeilisearchException {
+        var task = this.index.updateSearchableAttributesSettings(SEARCH_ATTRIBUTES);
+        this.index.waitForTask(task.getTaskUid(), TASK_WAIT_TIMEOUT_MS, TASK_WAIT_INTERVAL_MS);
+
+        task = this.index.updateFilterableAttributesSettings(FILTERABLE_ATTRIBUTES);
+        this.index.waitForTask(task.getTaskUid(), TASK_WAIT_TIMEOUT_MS, TASK_WAIT_INTERVAL_MS);
+
+        task = this.index.updateDisplayedAttributesSettings(DISPLAYED_ATTRIBUTES);
+        this.index.waitForTask(task.getTaskUid(), TASK_WAIT_TIMEOUT_MS, TASK_WAIT_INTERVAL_MS);
+    }
+
+    private void validateIndexSettings() throws MeilisearchException {
+        var searchableAttributes = this.index.getSearchableAttributesSettings();
+        if (!containsAll(searchableAttributes, SEARCH_ATTRIBUTES)) {
+            throw new MeilisearchException(
+                "Meilisearch searchable attributes were not applied, actual: "
+                    + Arrays.toString(searchableAttributes));
+        }
+
+        var filterableAttributes = this.index.getFilterableAttributesSettings();
+        if (!containsAll(filterableAttributes, FILTERABLE_ATTRIBUTES)) {
+            throw new MeilisearchException(
+                "Meilisearch filterable attributes were not applied, actual: "
+                    + Arrays.toString(filterableAttributes));
+        }
+
+        var displayedAttributes = this.index.getDisplayedAttributesSettings();
+        if (!containsAll(displayedAttributes, DISPLAYED_ATTRIBUTES)) {
+            throw new MeilisearchException(
+                "Meilisearch displayed attributes were not applied, actual: "
+                    + Arrays.toString(displayedAttributes));
+        }
+    }
+
+    private boolean containsAll(String[] actual, String[] expected) {
+        if (actual == null) {
+            return false;
+        }
+        var actualSet = Arrays.stream(actual)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+        if (actualSet.contains("*")) {
+            return true;
+        }
+        return Arrays.stream(expected).allMatch(actualSet::contains);
+    }
+
+    private void ensureIndexPrimaryKey(String indexName) throws MeilisearchException {
+        var existingIndex = getExistingIndex(indexName);
+        if (existingIndex == null) {
+            createIndexWithPrimaryKey(indexName);
+            return;
+        }
+
+        var primaryKey = existingIndex.getPrimaryKey();
+        if (primaryKey == null || DOCUMENT_PRIMARY_KEY.equals(primaryKey)) {
+            return;
+        }
+
+        log.warn("Recreating Meilisearch index {} because primary key is {}, expected {}",
+            indexName, primaryKey, DOCUMENT_PRIMARY_KEY);
+        var deleteTask = this.meilisearchClient.deleteIndex(indexName);
+        this.meilisearchClient.waitForTask(deleteTask.getTaskUid());
+        createIndexWithPrimaryKey(indexName);
+    }
+
+    private Index getExistingIndex(String indexName) throws MeilisearchException {
+        try {
+            return this.meilisearchClient.getIndex(indexName);
+        } catch (MeilisearchException e) {
+            log.debug("Meilisearch index {} does not exist or cannot be fetched", indexName, e);
+            return null;
+        }
+    }
+
+    private void createIndexWithPrimaryKey(String indexName) throws MeilisearchException {
+        var createTask = this.meilisearchClient.createIndex(indexName, DOCUMENT_PRIMARY_KEY);
+        this.meilisearchClient.waitForTask(createTask.getTaskUid());
+        this.index = this.meilisearchClient.index(indexName);
+        this.rebuildOnNextSuccessfulInitialization = true;
     }
 
     @Override
@@ -110,14 +364,22 @@ public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
             log.warn("Meilisearch is not available, skipping addOrUpdate");
             return;
         }
+        if (docs == null) {
+            log.warn("No documents provided, skipping addOrUpdate");
+            return;
+        }
 
         List<HaloDocument> documents = Streams.of(docs)
+            .filter(Objects::nonNull)
             .map(this::cleanDocument)
             .toList();
+        if (documents.isEmpty()) {
+            return;
+        }
 
         try {
             String documentsJson = JsonUtils.mapper().writeValueAsString(documents);
-            this.index.addDocuments(documentsJson, "metadataName");
+            this.index.addDocuments(documentsJson, DOCUMENT_PRIMARY_KEY);
         } catch (MeilisearchException | JsonProcessingException e) {
             log.error("Failed to add/update documents", e);
         }
@@ -129,14 +391,20 @@ public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
             log.warn("Meilisearch is not available, skipping deleteDocument");
             return;
         }
+        if (docIds == null) {
+            deleteAll();
+            return;
+        }
 
-        var metadataNames = Streams.of(docIds).map(id -> {
-            String[] split = id.split("-", 2);
-            return split.length > 1 ? split[1] : id;
-        }).toList();
+        var documentIds = Streams.of(docIds)
+            .filter(id -> id != null && !id.isBlank())
+            .toList();
+        if (documentIds.isEmpty()) {
+            return;
+        }
 
         try {
-            this.index.deleteDocuments(metadataNames);
+            this.index.deleteDocuments(documentIds);
         } catch (MeilisearchException e) {
             log.error("Failed to delete documents", e);
         }
@@ -159,7 +427,7 @@ public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
     @Override
     public run.halo.app.search.SearchResult search(SearchOption searchOption) {
         if (!available) {
-            return new run.halo.app.search.SearchResult();
+            return emptyResult(searchOption);
         }
 
         var filter = new StringJoiner(" AND ");
@@ -179,37 +447,33 @@ public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
             filter.add("published = " + filterPublished);
         }
 
-        var includeTypes = searchOption.getIncludeTypes();
-        if (includeTypes != null && !includeTypes.isEmpty()) {
+        var includeTypes = normalizeFilterValues(searchOption.getIncludeTypes());
+        if (!includeTypes.isEmpty()) {
             var typeFilter = includeTypes.stream()
-                .distinct()
                 .map(type -> "type = '" + type + "'")
                 .collect(Collectors.joining(" OR "));
             filter.add("(" + typeFilter + ")");
         }
 
-        var includeOwnerNames = searchOption.getIncludeOwnerNames();
-        if (includeOwnerNames != null && !includeOwnerNames.isEmpty()) {
+        var includeOwnerNames = normalizeFilterValues(searchOption.getIncludeOwnerNames());
+        if (!includeOwnerNames.isEmpty()) {
             var ownerFilter = includeOwnerNames.stream()
-                .distinct()
                 .map(owner -> "ownerName = '" + owner + "'")
                 .collect(Collectors.joining(" OR "));
             filter.add("(" + ownerFilter + ")");
         }
 
-        var includeTagNames = searchOption.getIncludeTagNames();
-        if (includeTagNames != null && !includeTagNames.isEmpty()) {
+        var includeTagNames = normalizeFilterValues(searchOption.getIncludeTagNames());
+        if (!includeTagNames.isEmpty()) {
             var tagFilter = includeTagNames.stream()
-                .distinct()
                 .map(tag -> "tags = '" + tag + "'")
                 .collect(Collectors.joining(" AND "));
             filter.add("(" + tagFilter + ")");
         }
 
-        var includeCategoryNames = searchOption.getIncludeCategoryNames();
-        if (includeCategoryNames != null && !includeCategoryNames.isEmpty()) {
+        var includeCategoryNames = normalizeFilterValues(searchOption.getIncludeCategoryNames());
+        if (!includeCategoryNames.isEmpty()) {
             var categoryFilter = includeCategoryNames.stream()
-                .distinct()
                 .map(category -> "categories = '" + category + "'")
                 .collect(Collectors.joining(" AND "));
             filter.add("(" + categoryFilter + ")");
@@ -230,43 +494,121 @@ public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
             searchRequestBuilder.filter(new String[]{filter.toString()});
         }
 
+        var searchRequest = searchRequestBuilder.build();
+
         try {
-            Searchable meilisearchResult = this.index.search(searchRequestBuilder.build());
-
-            var result = new run.halo.app.search.SearchResult();
-            result.setLimit(searchOption.getLimit());
-            result.setTotal((long) ((SearchResult) meilisearchResult).getEstimatedTotalHits());
-            result.setKeyword(searchOption.getKeyword());
-            result.setProcessingTimeMillis(meilisearchResult.getProcessingTimeMs());
-            result.setHits(convertHits(meilisearchResult.getHits()));
-
-            return result;
+            return doSearch(searchOption, searchRequest);
         } catch (MeilisearchException e) {
+            if (isInvalidSearchAttributesError(e) && recoverIndexSettingsAfterSearchFailure()) {
+                try {
+                    return doSearch(searchOption, searchRequest);
+                } catch (MeilisearchException retryException) {
+                    log.error("Failed to search after Meilisearch settings recovery",
+                        retryException);
+                    return emptyResult(searchOption);
+                }
+            }
             log.error("Failed to search", e);
-            return new run.halo.app.search.SearchResult();
+            return emptyResult(searchOption);
+        } catch (Exception e) {
+            log.error("Unexpected error during search", e);
+            return emptyResult(searchOption);
         }
     }
 
-    private List<HaloDocument> convertHits(List<HashMap<String, Object>> hits) {
-        return hits.stream()
-            .map(hit -> {
-                @SuppressWarnings("unchecked")
-                Map<String, Object> formatted = (Map<String, Object>) hit.get("_formatted");
-                if (formatted != null) {
-                    return JsonUtils.mapper().convertValue(formatted, HaloDocument.class);
-                } else {
-                    return JsonUtils.mapper().convertValue(hit, HaloDocument.class);
-                }
-            })
+    private run.halo.app.search.SearchResult doSearch(SearchOption searchOption,
+        SearchRequest searchRequest) throws MeilisearchException {
+        Searchable meilisearchResult = this.index.search(searchRequest);
+
+        var result = new run.halo.app.search.SearchResult();
+        result.setLimit(searchOption.getLimit());
+        result.setTotal((long) ((SearchResult) meilisearchResult).getEstimatedTotalHits());
+        result.setKeyword(searchOption.getKeyword());
+        result.setProcessingTimeMillis(meilisearchResult.getProcessingTimeMs());
+        result.setHits(convertHits(meilisearchResult.getHits()));
+
+        return result;
+    }
+
+    private boolean isInvalidSearchAttributesError(MeilisearchException e) {
+        if (e == null) {
+            return false;
+        }
+        var errorText = String.valueOf(e.getMessage()) + String.valueOf(e.getError())
+            + String.valueOf(e);
+        return errorText.contains("invalid_search_attributes_to_search_on");
+    }
+
+    private synchronized boolean recoverIndexSettingsAfterSearchFailure() {
+        if (!available || this.index == null) {
+            return false;
+        }
+        try {
+            log.warn("Recovering Meilisearch index settings after invalid searchable attributes");
+            initializeIndexSettings();
+            return true;
+        } catch (Exception recoveryError) {
+            log.error("Failed to recover Meilisearch index settings", recoveryError);
+            this.available = false;
+            if (hasUsableConfiguration(this.currentHost, this.currentIndexName)) {
+                cancelScheduledRetry();
+                scheduleRetry(this.currentHost, this.currentApiKey, this.currentIndexName);
+            }
+            return false;
+        }
+    }
+
+    private List<String> normalizeFilterValues(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return List.of();
+        }
+        return values.stream()
+            .filter(Objects::nonNull)
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .distinct()
             .toList();
+    }
+
+    private List<HaloDocument> convertHits(List<HashMap<String, Object>> hits) {
+        if (hits == null) {
+            return List.of();
+        }
+        return hits.stream()
+            .map(this::convertHit)
+            .filter(Objects::nonNull)
+            .toList();
+    }
+
+    private HaloDocument convertHit(HashMap<String, Object> hit) {
+        if (hit == null) {
+            return null;
+        }
+        try {
+            var formatted = hit.get("_formatted");
+            if (formatted instanceof Map<?, ?> formattedMap) {
+                return JsonUtils.mapper().convertValue(formattedMap, HaloDocument.class);
+            }
+            return JsonUtils.mapper().convertValue(hit, HaloDocument.class);
+        } catch (IllegalArgumentException e) {
+            log.warn("Failed to convert Meilisearch hit, skipping malformed hit", e);
+            return null;
+        }
     }
 
     @Override
     public void destroy() throws Exception {
-        this.available = false;
+        synchronized (this) {
+            this.disposed = true;
+            this.pluginStarted = false;
+            this.rebuildPending = false;
+            cancelScheduledRetry();
+            resetState();
+        }
+        this.retryExecutor.shutdownNow();
     }
 
-    @Override
+    @EventListener
     public void onApplicationEvent(ConfigUpdatedEvent event) {
         var properties = event.getMeilisearchProperties();
 
@@ -274,12 +616,22 @@ public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
         var masterKey = properties.getMasterKey();
         var indexName = properties.getIndexName();
 
-        if (host == null || host.isEmpty()) {
-            log.warn("Meilisearch host is not configured");
-            return;
-        }
-
         refresh(host, masterKey, indexName);
+    }
+
+    @EventListener
+    public void onApplicationEvent(PluginStartedEvent event) {
+        var shouldPublishRebuild = false;
+        synchronized (this) {
+            this.pluginStarted = true;
+            if (this.available && this.rebuildPending) {
+                this.rebuildPending = false;
+                shouldPublishRebuild = true;
+            }
+        }
+        if (shouldPublishRebuild) {
+            publishRebuildRequest();
+        }
     }
 
     @Override
@@ -287,6 +639,7 @@ public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
         var configMapOpt = client.fetch(ConfigMap.class, "meilisearch-engine-config");
         if (configMapOpt.isEmpty()) {
             log.warn("Meilisearch configuration not found");
+            this.rebuildOnNextSuccessfulInitialization = true;
             return;
         }
 
@@ -294,6 +647,7 @@ public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
         var data = configMap.getData();
         if (data == null || !data.containsKey("basic")) {
             log.warn("Meilisearch configuration data is missing");
+            this.rebuildOnNextSuccessfulInitialization = true;
             return;
         }
 
@@ -303,11 +657,25 @@ public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
             var masterKey = properties.getMasterKey();
             var indexName = properties.getIndexName();
 
-            if (host != null && !host.isEmpty()) {
-                refresh(host, masterKey, indexName);
-            }
+            refresh(host, masterKey, indexName);
         } catch (Exception e) {
             log.error("Failed to parse Meilisearch configuration", e);
+            this.rebuildOnNextSuccessfulInitialization = true;
         }
+    }
+
+    private run.halo.app.search.SearchResult emptyResult(SearchOption searchOption) {
+        var result = new run.halo.app.search.SearchResult();
+        result.setHits(List.of());
+        result.setTotal(0L);
+        if (searchOption != null) {
+            result.setKeyword(searchOption.getKeyword());
+            result.setLimit(searchOption.getLimit());
+        }
+        return result;
+    }
+
+    interface ClientFactory {
+        Client create(Config config);
     }
 }

--- a/src/main/java/run/halo/meilisearch/MeilisearchSearchEngine.java
+++ b/src/main/java/run/halo/meilisearch/MeilisearchSearchEngine.java
@@ -285,6 +285,22 @@ public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
         }
     }
 
+    private void waitForClientTaskSucceeded(TaskInfo taskInfo, String operation)
+        throws MeilisearchException {
+        if (taskInfo == null) {
+            throw new MeilisearchException("Meilisearch task was not created while trying to "
+                + operation);
+        }
+        var taskUid = taskInfo.getTaskUid();
+        this.meilisearchClient.waitForTask(taskUid);
+
+        var task = this.meilisearchClient.getTask(taskUid);
+        if (task == null || task.getStatus() != TaskStatus.SUCCEEDED) {
+            throw new MeilisearchException("Meilisearch task failed while trying to "
+                + operation + ": " + describeTask(task));
+        }
+    }
+
     private String describeTask(Task task) {
         if (task == null) {
             return "task not found";
@@ -348,7 +364,7 @@ public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
         log.warn("Recreating Meilisearch index {} because primary key is {}, expected {}",
             indexName, primaryKey, DOCUMENT_PRIMARY_KEY);
         var deleteTask = this.meilisearchClient.deleteIndex(indexName);
-        this.meilisearchClient.waitForTask(deleteTask.getTaskUid());
+        waitForClientTaskSucceeded(deleteTask, "delete legacy index");
         createIndexWithPrimaryKey(indexName);
     }
 
@@ -363,7 +379,7 @@ public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
 
     private void createIndexWithPrimaryKey(String indexName) throws MeilisearchException {
         var createTask = this.meilisearchClient.createIndex(indexName, DOCUMENT_PRIMARY_KEY);
-        this.meilisearchClient.waitForTask(createTask.getTaskUid());
+        waitForClientTaskSucceeded(createTask, "create index with primary key");
         this.index = this.meilisearchClient.index(indexName);
         this.rebuildOnNextSuccessfulInitialization = true;
     }

--- a/src/main/java/run/halo/meilisearch/MeilisearchSearchEngine.java
+++ b/src/main/java/run/halo/meilisearch/MeilisearchSearchEngine.java
@@ -1,6 +1,7 @@
 package run.halo.meilisearch;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.meilisearch.sdk.Client;
 import com.meilisearch.sdk.Config;
 import com.meilisearch.sdk.Index;
@@ -8,7 +9,15 @@ import com.meilisearch.sdk.SearchRequest;
 import com.meilisearch.sdk.exceptions.MeilisearchException;
 import com.meilisearch.sdk.model.SearchResult;
 import com.meilisearch.sdk.model.Searchable;
+import com.meilisearch.sdk.model.Settings;
+import com.meilisearch.sdk.model.Task;
+import com.meilisearch.sdk.model.TaskInfo;
+import com.meilisearch.sdk.model.TaskStatus;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
+import java.util.HexFormat;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +62,7 @@ public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
         "published", "recycled", "exposed", "ownerName", "creationTimestamp",
         "updateTimestamp", "permalink", "type", "content"
     };
-    private static final String DOCUMENT_PRIMARY_KEY = "id";
+    private static final String DOCUMENT_PRIMARY_KEY = "meilisearchId";
     private static final int TASK_WAIT_TIMEOUT_MS = 60_000;
     private static final int TASK_WAIT_INTERVAL_MS = 100;
     private static final int RETRY_DELAY_SECONDS = 5;
@@ -253,14 +262,39 @@ public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
     }
 
     private void updateIndexSettings() throws MeilisearchException {
-        var task = this.index.updateSearchableAttributesSettings(SEARCH_ATTRIBUTES);
-        this.index.waitForTask(task.getTaskUid(), TASK_WAIT_TIMEOUT_MS, TASK_WAIT_INTERVAL_MS);
+        var settings = new Settings()
+            .setSearchableAttributes(SEARCH_ATTRIBUTES)
+            .setFilterableAttributes(FILTERABLE_ATTRIBUTES)
+            .setDisplayedAttributes(DISPLAYED_ATTRIBUTES);
+        waitForTaskSucceeded(this.index.updateSettings(settings), "update index settings");
+    }
 
-        task = this.index.updateFilterableAttributesSettings(FILTERABLE_ATTRIBUTES);
-        this.index.waitForTask(task.getTaskUid(), TASK_WAIT_TIMEOUT_MS, TASK_WAIT_INTERVAL_MS);
+    private void waitForTaskSucceeded(TaskInfo taskInfo, String operation)
+        throws MeilisearchException {
+        if (taskInfo == null) {
+            throw new MeilisearchException("Meilisearch task was not created while trying to "
+                + operation);
+        }
+        var taskUid = taskInfo.getTaskUid();
+        this.index.waitForTask(taskUid, TASK_WAIT_TIMEOUT_MS, TASK_WAIT_INTERVAL_MS);
 
-        task = this.index.updateDisplayedAttributesSettings(DISPLAYED_ATTRIBUTES);
-        this.index.waitForTask(task.getTaskUid(), TASK_WAIT_TIMEOUT_MS, TASK_WAIT_INTERVAL_MS);
+        var task = this.index.getTask(taskUid);
+        if (task == null || task.getStatus() != TaskStatus.SUCCEEDED) {
+            throw new MeilisearchException("Meilisearch task failed while trying to "
+                + operation + ": " + describeTask(task));
+        }
+    }
+
+    private String describeTask(Task task) {
+        if (task == null) {
+            return "task not found";
+        }
+        var message = "status=" + task.getStatus();
+        var error = task.getError();
+        if (error != null && error.getMessage() != null) {
+            message += ", error=" + error.getMessage();
+        }
+        return message;
     }
 
     private void validateIndexSettings() throws MeilisearchException {
@@ -369,9 +403,10 @@ public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
             return;
         }
 
-        List<HaloDocument> documents = Streams.of(docs)
+        List<ObjectNode> documents = Streams.of(docs)
             .filter(Objects::nonNull)
             .map(this::cleanDocument)
+            .map(this::toMeilisearchDocument)
             .toList();
         if (documents.isEmpty()) {
             return;
@@ -379,9 +414,28 @@ public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
 
         try {
             String documentsJson = JsonUtils.mapper().writeValueAsString(documents);
-            this.index.addDocuments(documentsJson, DOCUMENT_PRIMARY_KEY);
+            waitForTaskSucceeded(
+                this.index.addDocuments(documentsJson, DOCUMENT_PRIMARY_KEY),
+                "add or update documents"
+            );
         } catch (MeilisearchException | JsonProcessingException e) {
             log.error("Failed to add/update documents", e);
+        }
+    }
+
+    private ObjectNode toMeilisearchDocument(HaloDocument document) {
+        ObjectNode documentNode = JsonUtils.mapper().valueToTree(document);
+        documentNode.put(DOCUMENT_PRIMARY_KEY, toMeilisearchDocumentId(document.getId()));
+        return documentNode;
+    }
+
+    private String toMeilisearchDocumentId(String haloDocumentId) {
+        try {
+            var digest = MessageDigest.getInstance("SHA-256");
+            var hash = digest.digest(haloDocumentId.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 message digest is not available", e);
         }
     }
 
@@ -398,13 +452,14 @@ public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
 
         var documentIds = Streams.of(docIds)
             .filter(id -> id != null && !id.isBlank())
+            .map(this::toMeilisearchDocumentId)
             .toList();
         if (documentIds.isEmpty()) {
             return;
         }
 
         try {
-            this.index.deleteDocuments(documentIds);
+            waitForTaskSucceeded(this.index.deleteDocuments(documentIds), "delete documents");
         } catch (MeilisearchException e) {
             log.error("Failed to delete documents", e);
         }
@@ -418,7 +473,7 @@ public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
         }
 
         try {
-            this.index.deleteAllDocuments();
+            waitForTaskSucceeded(this.index.deleteAllDocuments(), "delete all documents");
         } catch (MeilisearchException e) {
             log.error("Failed to delete all documents", e);
         }
@@ -482,7 +537,6 @@ public class MeilisearchSearchEngine implements SearchEngine, DisposableBean,
         var searchRequestBuilder = SearchRequest.builder()
             .q(searchOption.getKeyword())
             .limit(searchOption.getLimit())
-            .attributesToSearchOn(SEARCH_ATTRIBUTES)
             .attributesToHighlight(HIGHLIGHT_ATTRIBUTES)
             .highlightPreTag(searchOption.getHighlightPreTag())
             .highlightPostTag(searchOption.getHighlightPostTag())

--- a/src/test/java/run/halo/meilisearch/ConfigListenerTest.java
+++ b/src/test/java/run/halo/meilisearch/ConfigListenerTest.java
@@ -1,0 +1,191 @@
+package run.halo.meilisearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import run.halo.app.extension.ConfigMap;
+import run.halo.app.extension.ExtensionClient;
+import run.halo.app.extension.Metadata;
+import run.halo.app.extension.controller.Controller;
+import run.halo.app.extension.controller.ControllerBuilder;
+import run.halo.app.extension.controller.Reconciler;
+
+@ExtendWith(MockitoExtension.class)
+class ConfigListenerTest {
+
+    @Mock
+    ExtensionClient client;
+
+    @Mock
+    ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    ControllerBuilder controllerBuilder;
+
+    @Mock
+    Controller controller;
+
+    @Test
+    void reconcileShouldIgnoreMissingConfigMap() {
+        var listener = new ConfigListener(client, eventPublisher);
+        when(client.fetch(ConfigMap.class, "meilisearch-engine-config"))
+            .thenReturn(Optional.empty());
+
+        var result = listener.reconcile(new Reconciler.Request("meilisearch-engine-config"));
+
+        assertThat(result).isEqualTo(Reconciler.Result.doNotRetry());
+        verifyNoInteractions(eventPublisher);
+    }
+
+    @Test
+    void reconcileShouldIgnoreUnexpectedConfigMapRequest() {
+        var listener = new ConfigListener(client, eventPublisher);
+
+        var result = listener.reconcile(new Reconciler.Request("another-plugin-config"));
+
+        assertThat(result).isEqualTo(Reconciler.Result.doNotRetry());
+        verifyNoInteractions(client, eventPublisher);
+    }
+
+    @Test
+    void reconcileShouldIgnoreConfigMapWithoutData() {
+        var listener = new ConfigListener(client, eventPublisher);
+        var configMap = new ConfigMap();
+        configMap.setData(null);
+        when(client.fetch(ConfigMap.class, "meilisearch-engine-config"))
+            .thenReturn(Optional.of(configMap));
+
+        var result = listener.reconcile(new Reconciler.Request("meilisearch-engine-config"));
+
+        assertThat(result).isEqualTo(Reconciler.Result.doNotRetry());
+        verifyNoInteractions(eventPublisher);
+    }
+
+    @Test
+    void reconcileShouldIgnoreConfigMapWithoutBasicGroup() {
+        var listener = new ConfigListener(client, eventPublisher);
+        var configMap = new ConfigMap();
+        configMap.setData(Map.of("other", "{}"));
+        when(client.fetch(ConfigMap.class, "meilisearch-engine-config"))
+            .thenReturn(Optional.of(configMap));
+
+        var result = listener.reconcile(new Reconciler.Request("meilisearch-engine-config"));
+
+        assertThat(result).isEqualTo(Reconciler.Result.doNotRetry());
+        verifyNoInteractions(eventPublisher);
+    }
+
+    @Test
+    void reconcileShouldIgnoreDeletedConfigMap() {
+        var listener = new ConfigListener(client, eventPublisher);
+        var metadata = new Metadata();
+        metadata.setDeletionTimestamp(Instant.now());
+        var configMap = new ConfigMap();
+        configMap.setMetadata(metadata);
+        configMap.setData(Map.of("basic", """
+            {
+              "host": "http://meilisearch:7700",
+              "masterKey": "secret",
+              "indexName": "halo"
+            }
+            """));
+        when(client.fetch(ConfigMap.class, "meilisearch-engine-config"))
+            .thenReturn(Optional.of(configMap));
+
+        var result = listener.reconcile(new Reconciler.Request("meilisearch-engine-config"));
+
+        assertThat(result).isEqualTo(Reconciler.Result.doNotRetry());
+        verifyNoInteractions(eventPublisher);
+    }
+
+    @Test
+    void reconcileShouldIgnoreMalformedConfig() {
+        var listener = new ConfigListener(client, eventPublisher);
+        var configMap = new ConfigMap();
+        configMap.setData(Map.of("basic", "{"));
+        when(client.fetch(ConfigMap.class, "meilisearch-engine-config"))
+            .thenReturn(Optional.of(configMap));
+
+        var result = listener.reconcile(new Reconciler.Request("meilisearch-engine-config"));
+
+        assertThat(result).isEqualTo(Reconciler.Result.doNotRetry());
+        verifyNoInteractions(eventPublisher);
+    }
+
+    @Test
+    void reconcileShouldIgnoreIncompleteConfig() {
+        var listener = new ConfigListener(client, eventPublisher);
+        var configMap = new ConfigMap();
+        configMap.setData(Map.of("basic", """
+            {
+              "host": "",
+              "masterKey": "secret",
+              "indexName": "halo"
+            }
+            """));
+        when(client.fetch(ConfigMap.class, "meilisearch-engine-config"))
+            .thenReturn(Optional.of(configMap));
+
+        var result = listener.reconcile(new Reconciler.Request("meilisearch-engine-config"));
+
+        assertThat(result).isEqualTo(Reconciler.Result.doNotRetry());
+        verifyNoInteractions(eventPublisher);
+    }
+
+    @Test
+    void reconcileShouldPublishConfigUpdatedEvent() {
+        var listener = new ConfigListener(client, eventPublisher);
+        var configMap = new ConfigMap();
+        configMap.setData(Map.of("basic", """
+            {
+              "host": "http://meilisearch:7700",
+              "masterKey": "secret",
+              "indexName": "halo"
+            }
+            """));
+        when(client.fetch(ConfigMap.class, "meilisearch-engine-config"))
+            .thenReturn(Optional.of(configMap));
+
+        var result = listener.reconcile(new Reconciler.Request("meilisearch-engine-config"));
+
+        assertThat(result).isEqualTo(Reconciler.Result.doNotRetry());
+        var eventCaptor = ArgumentCaptor.forClass(ApplicationEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue()).isInstanceOf(ConfigUpdatedEvent.class);
+        var properties =
+            ((ConfigUpdatedEvent) eventCaptor.getValue()).getMeilisearchProperties();
+        assertThat(properties.getHost()).isEqualTo("http://meilisearch:7700");
+        assertThat(properties.getMasterKey()).isEqualTo("secret");
+        assertThat(properties.getIndexName()).isEqualTo("halo");
+    }
+
+    @Test
+    void setupWithShouldSyncExistingConfigMapOnStart() {
+        var listener = new ConfigListener(client, eventPublisher);
+        when(controllerBuilder.extension(any(ConfigMap.class))).thenReturn(controllerBuilder);
+        when(controllerBuilder.syncAllOnStart(anyBoolean())).thenReturn(controllerBuilder);
+        when(controllerBuilder.onAddMatcher(any())).thenReturn(controllerBuilder);
+        when(controllerBuilder.onDeleteMatcher(any())).thenReturn(controllerBuilder);
+        when(controllerBuilder.onUpdateMatcher(any())).thenReturn(controllerBuilder);
+        when(controllerBuilder.build()).thenReturn(controller);
+
+        var result = listener.setupWith(controllerBuilder);
+
+        assertThat(result).isSameAs(controller);
+        verify(controllerBuilder).syncAllOnStart(true);
+    }
+}

--- a/src/test/java/run/halo/meilisearch/MeilisearchSearchEngineTest.java
+++ b/src/test/java/run/halo/meilisearch/MeilisearchSearchEngineTest.java
@@ -111,6 +111,12 @@ class MeilisearchSearchEngineTest {
     TaskInfo createIndexTaskInfo;
 
     @Mock
+    Task deleteIndexTask;
+
+    @Mock
+    Task createIndexTask;
+
+    @Mock
     SearchResult searchResult;
 
     @Mock
@@ -656,7 +662,7 @@ class MeilisearchSearchEngineTest {
         when(meilisearchClient.getIndex("halo"))
             .thenThrow(new MeilisearchException("index not found"));
         when(meilisearchClient.createIndex("halo", "meilisearchId")).thenReturn(createIndexTaskInfo);
-        when(createIndexTaskInfo.getTaskUid()).thenReturn(321);
+        givenClientTaskSucceeded(createIndexTaskInfo, createIndexTask, 321);
         givenSuccessfulSettingsInitialization(index, taskInfo, 123);
         var engine = newEngine();
         engine.onApplicationEvent(new PluginStartedEvent(this));
@@ -665,6 +671,7 @@ class MeilisearchSearchEngineTest {
 
         assertThat(engine.available()).isTrue();
         verify(meilisearchClient).waitForTask(321);
+        verify(meilisearchClient).getTask(321);
         verify(eventPublisher).publishEvent(isA(HaloDocumentRebuildRequestEvent.class));
     }
 
@@ -675,9 +682,9 @@ class MeilisearchSearchEngineTest {
         when(meilisearchClient.getIndex("halo")).thenReturn(legacyIndex);
         when(legacyIndex.getPrimaryKey()).thenReturn("metadataName");
         when(meilisearchClient.deleteIndex("halo")).thenReturn(deleteIndexTaskInfo);
-        when(deleteIndexTaskInfo.getTaskUid()).thenReturn(111);
+        givenClientTaskSucceeded(deleteIndexTaskInfo, deleteIndexTask, 111);
         when(meilisearchClient.createIndex("halo", "meilisearchId")).thenReturn(createIndexTaskInfo);
-        when(createIndexTaskInfo.getTaskUid()).thenReturn(222);
+        givenClientTaskSucceeded(createIndexTaskInfo, createIndexTask, 222);
         givenSuccessfulSettingsInitialization(recreatedIndex, taskInfo, 333);
         var engine = newEngine();
 
@@ -685,13 +692,64 @@ class MeilisearchSearchEngineTest {
 
         assertThat(engine.available()).isTrue();
         verify(meilisearchClient).waitForTask(111);
+        verify(meilisearchClient).getTask(111);
         verify(meilisearchClient).waitForTask(222);
+        verify(meilisearchClient).getTask(222);
         verify(recreatedIndex).waitForTask(333, 60_000, 100);
         verify(eventPublisher, never()).publishEvent(isA(HaloDocumentRebuildRequestEvent.class));
 
         engine.onApplicationEvent(new PluginStartedEvent(this));
 
         verify(eventPublisher).publishEvent(isA(HaloDocumentRebuildRequestEvent.class));
+    }
+
+    @Test
+    void initializationShouldRetryWhenCreateIndexTaskFails() throws Exception {
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        when(meilisearchClient.index("halo")).thenReturn(index);
+        when(meilisearchClient.getIndex("halo"))
+            .thenThrow(new MeilisearchException("index not found"));
+        when(meilisearchClient.createIndex("halo", "meilisearchId")).thenReturn(createIndexTaskInfo);
+        when(createIndexTaskInfo.getTaskUid()).thenReturn(321);
+        when(meilisearchClient.getTask(321)).thenReturn(createIndexTask);
+        when(createIndexTask.getStatus()).thenReturn(TaskStatus.FAILED);
+        doReturn(retryFuture)
+            .when(retryExecutor)
+            .schedule(any(Runnable.class), eq(5L), eq(TimeUnit.SECONDS));
+        var engine = newEngine();
+
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+
+        assertThat(engine.available()).isFalse();
+        verify(meilisearchClient).waitForTask(321);
+        verify(meilisearchClient).getTask(321);
+        verify(index, never()).updateSettings(any(Settings.class));
+        verify(retryExecutor).schedule(any(Runnable.class), eq(5L), eq(TimeUnit.SECONDS));
+    }
+
+    @Test
+    void initializationShouldRetryWhenDeleteLegacyIndexTaskFails() throws Exception {
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        when(meilisearchClient.index("halo")).thenReturn(index);
+        when(meilisearchClient.getIndex("halo")).thenReturn(legacyIndex);
+        when(legacyIndex.getPrimaryKey()).thenReturn("metadataName");
+        when(meilisearchClient.deleteIndex("halo")).thenReturn(deleteIndexTaskInfo);
+        when(deleteIndexTaskInfo.getTaskUid()).thenReturn(111);
+        when(meilisearchClient.getTask(111)).thenReturn(deleteIndexTask);
+        when(deleteIndexTask.getStatus()).thenReturn(TaskStatus.FAILED);
+        doReturn(retryFuture)
+            .when(retryExecutor)
+            .schedule(any(Runnable.class), eq(5L), eq(TimeUnit.SECONDS));
+        var engine = newEngine();
+
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+
+        assertThat(engine.available()).isFalse();
+        verify(meilisearchClient).waitForTask(111);
+        verify(meilisearchClient).getTask(111);
+        verify(meilisearchClient, never()).createIndex("halo", "meilisearchId");
+        verify(index, never()).updateSettings(any(Settings.class));
+        verify(retryExecutor).schedule(any(Runnable.class), eq(5L), eq(TimeUnit.SECONDS));
     }
 
     private void givenSuccessfulInitialization(Client client, Index index, TaskInfo taskInfo,
@@ -720,6 +778,13 @@ class MeilisearchSearchEngineTest {
         throws Exception {
         when(taskInfo.getTaskUid()).thenReturn(taskUid);
         when(index.getTask(taskUid)).thenReturn(task);
+        when(task.getStatus()).thenReturn(TaskStatus.SUCCEEDED);
+    }
+
+    private void givenClientTaskSucceeded(TaskInfo taskInfo, Task task, int taskUid)
+        throws Exception {
+        when(taskInfo.getTaskUid()).thenReturn(taskUid);
+        when(meilisearchClient.getTask(taskUid)).thenReturn(task);
         when(task.getStatus()).thenReturn(TaskStatus.SUCCEEDED);
     }
 

--- a/src/test/java/run/halo/meilisearch/MeilisearchSearchEngineTest.java
+++ b/src/test/java/run/halo/meilisearch/MeilisearchSearchEngineTest.java
@@ -20,7 +20,10 @@ import com.meilisearch.sdk.Index;
 import com.meilisearch.sdk.SearchRequest;
 import com.meilisearch.sdk.exceptions.MeilisearchException;
 import com.meilisearch.sdk.model.SearchResult;
+import com.meilisearch.sdk.model.Settings;
+import com.meilisearch.sdk.model.Task;
 import com.meilisearch.sdk.model.TaskInfo;
+import com.meilisearch.sdk.model.TaskStatus;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -37,6 +40,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import run.halo.app.extension.ConfigMap;
 import run.halo.app.extension.ExtensionClient;
+import run.halo.app.infra.utils.JsonUtils;
 import run.halo.app.plugin.event.PluginStartedEvent;
 import run.halo.app.search.HaloDocument;
 import run.halo.app.search.SearchOption;
@@ -95,6 +99,12 @@ class MeilisearchSearchEngineTest {
     TaskInfo retryTaskInfo;
 
     @Mock
+    Task task;
+
+    @Mock
+    Task retryTask;
+
+    @Mock
     TaskInfo deleteIndexTaskInfo;
 
     @Mock
@@ -102,6 +112,24 @@ class MeilisearchSearchEngineTest {
 
     @Mock
     SearchResult searchResult;
+
+    @Mock
+    TaskInfo documentTaskInfo;
+
+    @Mock
+    Task documentTask;
+
+    @Mock
+    TaskInfo deleteTaskInfo;
+
+    @Mock
+    Task deleteTask;
+
+    @Mock
+    TaskInfo deleteAllTaskInfo;
+
+    @Mock
+    Task deleteAllTask;
 
     @Test
     void configUpdatedEventShouldInitializeIndexSettingsBeforeBecomingAvailable()
@@ -113,20 +141,17 @@ class MeilisearchSearchEngineTest {
         engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
 
         assertThat(engine.available()).isTrue();
-        var searchableAttributesCaptor = ArgumentCaptor.forClass(String[].class);
-        var filterableAttributesCaptor = ArgumentCaptor.forClass(String[].class);
-        var displayedAttributesCaptor = ArgumentCaptor.forClass(String[].class);
-        verify(index).updateSearchableAttributesSettings(searchableAttributesCaptor.capture());
-        verify(index).updateFilterableAttributesSettings(filterableAttributesCaptor.capture());
-        verify(index).updateDisplayedAttributesSettings(displayedAttributesCaptor.capture());
-        assertThat(searchableAttributesCaptor.getValue())
+        var settingsCaptor = ArgumentCaptor.forClass(Settings.class);
+        verify(index).updateSettings(settingsCaptor.capture());
+        assertThat(settingsCaptor.getValue().getSearchableAttributes())
             .containsExactly("title", "description", "content");
-        assertThat(filterableAttributesCaptor.getValue())
+        assertThat(settingsCaptor.getValue().getFilterableAttributes())
             .containsExactly("published", "recycled", "exposed", "type", "ownerName",
                 "categories", "tags");
-        assertThat(displayedAttributesCaptor.getValue())
+        assertThat(settingsCaptor.getValue().getDisplayedAttributes())
             .contains("ownerName", "content", "permalink");
-        verify(index, times(3)).waitForTask(123, 60_000, 100);
+        verify(index).waitForTask(123, 60_000, 100);
+        verify(index).getTask(123);
         verify(retryExecutor, never()).schedule(any(Runnable.class), anyLong(),
             any(TimeUnit.class));
         verify(eventPublisher, never()).publishEvent(isA(HaloDocumentRebuildRequestEvent.class));
@@ -172,7 +197,7 @@ class MeilisearchSearchEngineTest {
 
         assertThat(engine.available()).isTrue();
         verify(clientFactory, times(1)).create(any(Config.class));
-        verify(index, times(1)).updateSearchableAttributesSettings(any(String[].class));
+        verify(index, times(1)).updateSettings(any(Settings.class));
     }
 
     @Test
@@ -181,7 +206,7 @@ class MeilisearchSearchEngineTest {
             .thenReturn(meilisearchClient, retryMeilisearchClient);
         when(meilisearchClient.index("halo")).thenReturn(index);
         when(meilisearchClient.getIndex("halo")).thenReturn(index);
-        when(index.updateSearchableAttributesSettings(any(String[].class)))
+        when(index.updateSettings(any(Settings.class)))
             .thenThrow(new RuntimeException("not ready"));
         var retryTaskCaptor = ArgumentCaptor.forClass(Runnable.class);
         doReturn(retryFuture)
@@ -199,7 +224,7 @@ class MeilisearchSearchEngineTest {
         retryTaskCaptor.getValue().run();
 
         assertThat(engine.available()).isTrue();
-        verify(retryIndex, times(3)).waitForTask(456, 60_000, 100);
+        verify(retryIndex).waitForTask(456, 60_000, 100);
         verify(eventPublisher).publishEvent(isA(HaloDocumentRebuildRequestEvent.class));
     }
 
@@ -209,7 +234,7 @@ class MeilisearchSearchEngineTest {
             .thenReturn(meilisearchClient, retryMeilisearchClient);
         when(meilisearchClient.index("halo")).thenReturn(index);
         when(meilisearchClient.getIndex("halo")).thenReturn(index);
-        when(index.updateSearchableAttributesSettings(any(String[].class)))
+        when(index.updateSettings(any(Settings.class)))
             .thenThrow(new RuntimeException("not ready"));
         var retryTaskCaptor = ArgumentCaptor.forClass(Runnable.class);
         doReturn(retryFuture)
@@ -237,7 +262,7 @@ class MeilisearchSearchEngineTest {
         when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
         when(meilisearchClient.index("halo")).thenReturn(index);
         when(meilisearchClient.getIndex("halo")).thenReturn(index);
-        when(index.updateSearchableAttributesSettings(any(String[].class)))
+        when(index.updateSettings(any(Settings.class)))
             .thenThrow(new RuntimeException("not ready"));
         var retryTaskCaptor = ArgumentCaptor.forClass(Runnable.class);
         doReturn(retryFuture)
@@ -262,7 +287,7 @@ class MeilisearchSearchEngineTest {
         when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
         when(meilisearchClient.index("halo")).thenReturn(index);
         when(meilisearchClient.getIndex("halo")).thenReturn(index);
-        when(index.updateSearchableAttributesSettings(any(String[].class)))
+        when(index.updateSettings(any(Settings.class)))
             .thenThrow(new RuntimeException("not ready"));
         doReturn(retryFuture)
             .when(retryExecutor)
@@ -403,9 +428,29 @@ class MeilisearchSearchEngineTest {
 
         assertThat(result.getTotal()).isEqualTo(1);
         assertThat(result.getHits()).hasSize(1);
-        verify(index, times(2)).updateSearchableAttributesSettings(any(String[].class));
+        verify(index, times(2)).updateSettings(any(Settings.class));
         verify(index, times(2)).search(any(SearchRequest.class));
         assertThat(engine.available()).isTrue();
+    }
+
+    @Test
+    void initializationShouldRetryWhenSettingsTaskFails() throws Exception {
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        when(meilisearchClient.index("halo")).thenReturn(index);
+        when(meilisearchClient.getIndex("halo")).thenReturn(index);
+        when(index.updateSettings(any(Settings.class))).thenReturn(taskInfo);
+        when(taskInfo.getTaskUid()).thenReturn(123);
+        when(index.getTask(123)).thenReturn(task);
+        when(task.getStatus()).thenReturn(TaskStatus.FAILED);
+        doReturn(retryFuture)
+            .when(retryExecutor)
+            .schedule(any(Runnable.class), eq(5L), eq(TimeUnit.SECONDS));
+        var engine = newEngine();
+
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+
+        assertThat(engine.available()).isFalse();
+        verify(retryExecutor).schedule(any(Runnable.class), eq(5L), eq(TimeUnit.SECONDS));
     }
 
     @Test
@@ -454,6 +499,7 @@ class MeilisearchSearchEngineTest {
             .containsExactly("recycled = false AND exposed = true AND published = true"
                 + " AND (type = 'post.content.halo.run') AND (ownerName = 'admin')"
                 + " AND (tags = 'tag-a') AND (categories = 'category-a' AND categories = 'category-b')");
+        assertThat(requestCaptor.getValue().getAttributesToSearchOn()).isNull();
     }
 
     @Test
@@ -487,13 +533,21 @@ class MeilisearchSearchEngineTest {
         var document = document();
         document.setDescription("<p>Hello <strong>Halo</strong></p>");
         document.setContent("<article>Search <em>content</em></article>");
+        givenTaskSucceeded(index, documentTaskInfo, documentTask, 789);
+        when(index.addDocuments(anyString(), eq("meilisearchId"))).thenReturn(documentTaskInfo);
 
         engine.addOrUpdate(List.of(document));
 
         var documentsCaptor = ArgumentCaptor.forClass(String.class);
-        verify(index).addDocuments(documentsCaptor.capture(), eq("id"));
+        verify(index).addDocuments(documentsCaptor.capture(), eq("meilisearchId"));
         assertThat(documentsCaptor.getValue()).contains("Hello Halo", "Search content");
         assertThat(documentsCaptor.getValue()).doesNotContain("<p>", "<strong>", "<article>", "<em>");
+        var indexedDocument = JsonUtils.mapper().readTree(documentsCaptor.getValue()).get(0);
+        assertThat(indexedDocument.get("id").asText()).isEqualTo("post.content.halo.run-post-name");
+        assertThat(indexedDocument.get("meilisearchId").asText())
+            .matches("[a-f0-9]{64}")
+            .doesNotContain(".");
+        verify(index).waitForTask(789, 60_000, 100);
     }
 
     @Test
@@ -520,13 +574,15 @@ class MeilisearchSearchEngineTest {
         documentsWithNull.add(null);
         engine.addOrUpdate(documentsWithNull);
 
-        verify(index, never()).addDocuments(anyString(), eq("id"));
+        verify(index, never()).addDocuments(anyString(), eq("meilisearchId"));
     }
 
     @Test
     void deleteDocumentShouldUseHaloDocumentIds() throws Exception {
         givenSuccessfulInitialization(meilisearchClient, index, taskInfo, "halo", 123);
         when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        givenTaskSucceeded(index, deleteTaskInfo, deleteTask, 790);
+        when(index.deleteDocuments(any())).thenReturn(deleteTaskInfo);
         var engine = newEngine();
         engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
 
@@ -535,10 +591,14 @@ class MeilisearchSearchEngineTest {
             "singlepage.content.halo.run-page-name"
         ));
 
-        verify(index).deleteDocuments(List.of(
-            "post.content.halo.run-post-name",
-            "singlepage.content.halo.run-page-name"
-        ));
+        var documentIdsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(index).deleteDocuments(documentIdsCaptor.capture());
+        assertThat(documentIdsCaptor.getValue())
+            .hasSize(2)
+            .allSatisfy(id -> assertThat((String) id)
+                .matches("[a-f0-9]{64}")
+                .doesNotContain("."));
+        verify(index).waitForTask(790, 60_000, 100);
     }
 
     @Test
@@ -562,6 +622,8 @@ class MeilisearchSearchEngineTest {
     void deleteDocumentShouldDeleteAllWhenDocumentIdsAreMissing() throws Exception {
         givenSuccessfulInitialization(meilisearchClient, index, taskInfo, "halo", 123);
         when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        givenTaskSucceeded(index, deleteAllTaskInfo, deleteAllTask, 791);
+        when(index.deleteAllDocuments()).thenReturn(deleteAllTaskInfo);
         var engine = newEngine();
         engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
 
@@ -569,6 +631,7 @@ class MeilisearchSearchEngineTest {
 
         verify(index).deleteAllDocuments();
         verify(index, never()).deleteDocuments(any());
+        verify(index).waitForTask(791, 60_000, 100);
     }
 
     @Test
@@ -592,7 +655,7 @@ class MeilisearchSearchEngineTest {
         when(meilisearchClient.index("halo")).thenReturn(index);
         when(meilisearchClient.getIndex("halo"))
             .thenThrow(new MeilisearchException("index not found"));
-        when(meilisearchClient.createIndex("halo", "id")).thenReturn(createIndexTaskInfo);
+        when(meilisearchClient.createIndex("halo", "meilisearchId")).thenReturn(createIndexTaskInfo);
         when(createIndexTaskInfo.getTaskUid()).thenReturn(321);
         givenSuccessfulSettingsInitialization(index, taskInfo, 123);
         var engine = newEngine();
@@ -613,7 +676,7 @@ class MeilisearchSearchEngineTest {
         when(legacyIndex.getPrimaryKey()).thenReturn("metadataName");
         when(meilisearchClient.deleteIndex("halo")).thenReturn(deleteIndexTaskInfo);
         when(deleteIndexTaskInfo.getTaskUid()).thenReturn(111);
-        when(meilisearchClient.createIndex("halo", "id")).thenReturn(createIndexTaskInfo);
+        when(meilisearchClient.createIndex("halo", "meilisearchId")).thenReturn(createIndexTaskInfo);
         when(createIndexTaskInfo.getTaskUid()).thenReturn(222);
         givenSuccessfulSettingsInitialization(recreatedIndex, taskInfo, 333);
         var engine = newEngine();
@@ -623,7 +686,7 @@ class MeilisearchSearchEngineTest {
         assertThat(engine.available()).isTrue();
         verify(meilisearchClient).waitForTask(111);
         verify(meilisearchClient).waitForTask(222);
-        verify(recreatedIndex, times(3)).waitForTask(333, 60_000, 100);
+        verify(recreatedIndex).waitForTask(333, 60_000, 100);
         verify(eventPublisher, never()).publishEvent(isA(HaloDocumentRebuildRequestEvent.class));
 
         engine.onApplicationEvent(new PluginStartedEvent(this));
@@ -648,10 +711,16 @@ class MeilisearchSearchEngineTest {
 
     private void givenSuccessfulSettingsUpdate(Index index, TaskInfo taskInfo, int taskUid)
         throws Exception {
-        when(index.updateSearchableAttributesSettings(any(String[].class))).thenReturn(taskInfo);
-        when(index.updateFilterableAttributesSettings(any(String[].class))).thenReturn(taskInfo);
-        when(index.updateDisplayedAttributesSettings(any(String[].class))).thenReturn(taskInfo);
+        var completedTask = taskInfo == this.taskInfo ? this.task : this.retryTask;
+        when(index.updateSettings(any(Settings.class))).thenReturn(taskInfo);
+        givenTaskSucceeded(index, taskInfo, completedTask, taskUid);
+    }
+
+    private void givenTaskSucceeded(Index index, TaskInfo taskInfo, Task task, int taskUid)
+        throws Exception {
         when(taskInfo.getTaskUid()).thenReturn(taskUid);
+        when(index.getTask(taskUid)).thenReturn(task);
+        when(task.getStatus()).thenReturn(TaskStatus.SUCCEEDED);
     }
 
     private MeilisearchSearchEngine newEngine() {

--- a/src/test/java/run/halo/meilisearch/MeilisearchSearchEngineTest.java
+++ b/src/test/java/run/halo/meilisearch/MeilisearchSearchEngineTest.java
@@ -1,0 +1,731 @@
+package run.halo.meilisearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.meilisearch.sdk.Client;
+import com.meilisearch.sdk.Config;
+import com.meilisearch.sdk.Index;
+import com.meilisearch.sdk.SearchRequest;
+import com.meilisearch.sdk.exceptions.MeilisearchException;
+import com.meilisearch.sdk.model.SearchResult;
+import com.meilisearch.sdk.model.TaskInfo;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import run.halo.app.extension.ConfigMap;
+import run.halo.app.extension.ExtensionClient;
+import run.halo.app.plugin.event.PluginStartedEvent;
+import run.halo.app.search.HaloDocument;
+import run.halo.app.search.SearchOption;
+import run.halo.app.search.event.HaloDocumentRebuildRequestEvent;
+
+@ExtendWith(MockitoExtension.class)
+class MeilisearchSearchEngineTest {
+
+    private static final String[] SEARCH_ATTRIBUTES = {"title", "description", "content"};
+    private static final String[] FILTERABLE_ATTRIBUTES = {
+        "published", "recycled", "exposed", "type", "ownerName", "categories", "tags"
+    };
+    private static final String[] DISPLAYED_ATTRIBUTES = {
+        "id", "metadataName", "title", "annotations", "description", "categories", "tags",
+        "published", "recycled", "exposed", "ownerName", "creationTimestamp",
+        "updateTimestamp", "permalink", "type", "content"
+    };
+
+    @Mock
+    ExtensionClient extensionClient;
+
+    @Mock
+    ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    MeilisearchSearchEngine.ClientFactory clientFactory;
+
+    @Mock
+    ScheduledExecutorService retryExecutor;
+
+    @Mock
+    ScheduledFuture<Object> retryFuture;
+
+    @Mock
+    Client meilisearchClient;
+
+    @Mock
+    Client retryMeilisearchClient;
+
+    @Mock
+    Index index;
+
+    @Mock
+    Index retryIndex;
+
+    @Mock
+    Index legacyIndex;
+
+    @Mock
+    Index recreatedIndex;
+
+    @Mock
+    TaskInfo taskInfo;
+
+    @Mock
+    TaskInfo retryTaskInfo;
+
+    @Mock
+    TaskInfo deleteIndexTaskInfo;
+
+    @Mock
+    TaskInfo createIndexTaskInfo;
+
+    @Mock
+    SearchResult searchResult;
+
+    @Test
+    void configUpdatedEventShouldInitializeIndexSettingsBeforeBecomingAvailable()
+        throws Exception {
+        givenSuccessfulInitialization(meilisearchClient, index, taskInfo, "halo", 123);
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        var engine = newEngine();
+
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+
+        assertThat(engine.available()).isTrue();
+        var searchableAttributesCaptor = ArgumentCaptor.forClass(String[].class);
+        var filterableAttributesCaptor = ArgumentCaptor.forClass(String[].class);
+        var displayedAttributesCaptor = ArgumentCaptor.forClass(String[].class);
+        verify(index).updateSearchableAttributesSettings(searchableAttributesCaptor.capture());
+        verify(index).updateFilterableAttributesSettings(filterableAttributesCaptor.capture());
+        verify(index).updateDisplayedAttributesSettings(displayedAttributesCaptor.capture());
+        assertThat(searchableAttributesCaptor.getValue())
+            .containsExactly("title", "description", "content");
+        assertThat(filterableAttributesCaptor.getValue())
+            .containsExactly("published", "recycled", "exposed", "type", "ownerName",
+                "categories", "tags");
+        assertThat(displayedAttributesCaptor.getValue())
+            .contains("ownerName", "content", "permalink");
+        verify(index, times(3)).waitForTask(123, 60_000, 100);
+        verify(retryExecutor, never()).schedule(any(Runnable.class), anyLong(),
+            any(TimeUnit.class));
+        verify(eventPublisher, never()).publishEvent(isA(HaloDocumentRebuildRequestEvent.class));
+    }
+
+    @Test
+    void blankConfigurationShouldBeIgnoredWithoutRetrying() {
+        var engine = newEngine();
+        var properties = properties();
+        properties.setHost(" ");
+
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties));
+
+        assertThat(engine.available()).isFalse();
+        verifyNoInteractions(clientFactory, retryExecutor, eventPublisher);
+    }
+
+    @Test
+    void blankConfigurationShouldNotDisableExistingEngine() throws Exception {
+        givenSuccessfulInitialization(meilisearchClient, index, taskInfo, "halo", 123);
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        var engine = newEngine();
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+        var properties = properties();
+        properties.setHost(" ");
+
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties));
+
+        assertThat(engine.available()).isTrue();
+        verify(clientFactory, times(1)).create(any(Config.class));
+        verify(retryExecutor, never()).schedule(any(Runnable.class), anyLong(),
+            any(TimeUnit.class));
+    }
+
+    @Test
+    void sameConfigurationShouldNotReinitializeClient() throws Exception {
+        givenSuccessfulInitialization(meilisearchClient, index, taskInfo, "halo", 123);
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        var engine = newEngine();
+
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+
+        assertThat(engine.available()).isTrue();
+        verify(clientFactory, times(1)).create(any(Config.class));
+        verify(index, times(1)).updateSearchableAttributesSettings(any(String[].class));
+    }
+
+    @Test
+    void initializationFailureShouldRetryAndRebuildAfterRecovery() throws Exception {
+        when(clientFactory.create(any(Config.class)))
+            .thenReturn(meilisearchClient, retryMeilisearchClient);
+        when(meilisearchClient.index("halo")).thenReturn(index);
+        when(meilisearchClient.getIndex("halo")).thenReturn(index);
+        when(index.updateSearchableAttributesSettings(any(String[].class)))
+            .thenThrow(new RuntimeException("not ready"));
+        var retryTaskCaptor = ArgumentCaptor.forClass(Runnable.class);
+        doReturn(retryFuture)
+            .when(retryExecutor)
+            .schedule(retryTaskCaptor.capture(), eq(5L), eq(TimeUnit.SECONDS));
+        givenSuccessfulInitialization(retryMeilisearchClient, retryIndex, retryTaskInfo, "halo", 456);
+        var engine = newEngine();
+
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+
+        assertThat(engine.available()).isFalse();
+        verify(retryExecutor).schedule(any(Runnable.class), eq(5L), eq(TimeUnit.SECONDS));
+
+        engine.onApplicationEvent(new PluginStartedEvent(this));
+        retryTaskCaptor.getValue().run();
+
+        assertThat(engine.available()).isTrue();
+        verify(retryIndex, times(3)).waitForTask(456, 60_000, 100);
+        verify(eventPublisher).publishEvent(isA(HaloDocumentRebuildRequestEvent.class));
+    }
+
+    @Test
+    void newConfigurationShouldCancelPendingRetryAndIgnoreStaleRetry() throws Exception {
+        when(clientFactory.create(any(Config.class)))
+            .thenReturn(meilisearchClient, retryMeilisearchClient);
+        when(meilisearchClient.index("halo")).thenReturn(index);
+        when(meilisearchClient.getIndex("halo")).thenReturn(index);
+        when(index.updateSearchableAttributesSettings(any(String[].class)))
+            .thenThrow(new RuntimeException("not ready"));
+        var retryTaskCaptor = ArgumentCaptor.forClass(Runnable.class);
+        doReturn(retryFuture)
+            .when(retryExecutor)
+            .schedule(retryTaskCaptor.capture(), eq(5L), eq(TimeUnit.SECONDS));
+        givenSuccessfulInitialization(retryMeilisearchClient, retryIndex, retryTaskInfo,
+            "new-index", 456);
+        var engine = newEngine();
+
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this,
+            properties("http://meilisearch-2:7700", "secret-2", "new-index")));
+
+        assertThat(engine.available()).isTrue();
+        verify(retryFuture).cancel(false);
+
+        retryTaskCaptor.getValue().run();
+
+        verify(clientFactory, times(2)).create(any(Config.class));
+        verify(eventPublisher, never()).publishEvent(isA(HaloDocumentRebuildRequestEvent.class));
+    }
+
+    @Test
+    void initializationRetryShouldStopAtRetryLimit() throws Exception {
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        when(meilisearchClient.index("halo")).thenReturn(index);
+        when(meilisearchClient.getIndex("halo")).thenReturn(index);
+        when(index.updateSearchableAttributesSettings(any(String[].class)))
+            .thenThrow(new RuntimeException("not ready"));
+        var retryTaskCaptor = ArgumentCaptor.forClass(Runnable.class);
+        doReturn(retryFuture)
+            .when(retryExecutor)
+            .schedule(retryTaskCaptor.capture(), eq(5L), eq(TimeUnit.SECONDS));
+        var engine = newEngine();
+
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+        for (var i = 0; i < 24; i++) {
+            var retryTasks = retryTaskCaptor.getAllValues();
+            retryTasks.get(retryTasks.size() - 1).run();
+        }
+
+        assertThat(engine.available()).isFalse();
+        verify(retryExecutor, times(24)).schedule(any(Runnable.class), eq(5L),
+            eq(TimeUnit.SECONDS));
+        verify(clientFactory, times(25)).create(any(Config.class));
+    }
+
+    @Test
+    void destroyShouldCancelRetryAndIgnoreFurtherUpdates() throws Exception {
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        when(meilisearchClient.index("halo")).thenReturn(index);
+        when(meilisearchClient.getIndex("halo")).thenReturn(index);
+        when(index.updateSearchableAttributesSettings(any(String[].class)))
+            .thenThrow(new RuntimeException("not ready"));
+        doReturn(retryFuture)
+            .when(retryExecutor)
+            .schedule(any(Runnable.class), eq(5L), eq(TimeUnit.SECONDS));
+        var engine = newEngine();
+
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+        engine.destroy();
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+
+        assertThat(engine.available()).isFalse();
+        verify(retryFuture).cancel(false);
+        verify(retryExecutor).shutdownNow();
+        verify(clientFactory, times(1)).create(any(Config.class));
+    }
+
+    @Test
+    void configUpdateShouldRebuildAfterStartupConfigurationWasMissing() throws Exception {
+        when(extensionClient.fetch(ConfigMap.class, "meilisearch-engine-config"))
+            .thenReturn(Optional.empty());
+        givenSuccessfulInitialization(meilisearchClient, index, taskInfo, "halo", 123);
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        var engine = newEngine();
+
+        engine.afterPropertiesSet();
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+
+        assertThat(engine.available()).isTrue();
+        verify(eventPublisher, never()).publishEvent(isA(HaloDocumentRebuildRequestEvent.class));
+
+        engine.onApplicationEvent(new PluginStartedEvent(this));
+
+        verify(eventPublisher).publishEvent(isA(HaloDocumentRebuildRequestEvent.class));
+    }
+
+    @Test
+    void configUpdateShouldRebuildAfterStartupConfigurationWasMalformed() throws Exception {
+        var configMap = new ConfigMap();
+        configMap.setData(Map.of("basic", "{"));
+        when(extensionClient.fetch(ConfigMap.class, "meilisearch-engine-config"))
+            .thenReturn(Optional.of(configMap));
+        givenSuccessfulInitialization(meilisearchClient, index, taskInfo, "halo", 123);
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        var engine = newEngine();
+
+        engine.afterPropertiesSet();
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+
+        assertThat(engine.available()).isTrue();
+        verify(eventPublisher, never()).publishEvent(isA(HaloDocumentRebuildRequestEvent.class));
+
+        engine.onApplicationEvent(new PluginStartedEvent(this));
+
+        verify(eventPublisher).publishEvent(isA(HaloDocumentRebuildRequestEvent.class));
+    }
+
+    @Test
+    void rebuildEventFailureShouldNotMakeRecoveredEngineUnavailable() throws Exception {
+        when(extensionClient.fetch(ConfigMap.class, "meilisearch-engine-config"))
+            .thenReturn(Optional.empty());
+        givenSuccessfulInitialization(meilisearchClient, index, taskInfo, "halo", 123);
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        doThrow(new RuntimeException("listener failed"))
+            .when(eventPublisher)
+            .publishEvent(isA(HaloDocumentRebuildRequestEvent.class));
+        var engine = newEngine();
+
+        engine.afterPropertiesSet();
+        engine.onApplicationEvent(new PluginStartedEvent(this));
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+
+        assertThat(engine.available()).isTrue();
+        verify(retryExecutor, never()).schedule(any(Runnable.class), anyLong(),
+            any(TimeUnit.class));
+    }
+
+    @Test
+    void unavailableSearchShouldReturnEmptyResultWithRequestMetadata() {
+        var engine = newEngine();
+        var option = searchOption();
+
+        var result = engine.search(option);
+
+        assertThat(result.getKeyword()).isEqualTo("halo");
+        assertThat(result.getLimit()).isEqualTo(20);
+        assertThat(result.getTotal()).isZero();
+        assertThat(result.getHits()).isEmpty();
+    }
+
+    @Test
+    void searchShouldReturnEmptyResultWhenMeilisearchThrows() throws Exception {
+        givenSuccessfulInitialization(meilisearchClient, index, taskInfo, "halo", 123);
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        when(index.search(any(SearchRequest.class))).thenThrow(new MeilisearchException("boom"));
+        var engine = newEngine();
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+        var option = searchOption();
+
+        var result = engine.search(option);
+
+        assertThat(result.getKeyword()).isEqualTo("halo");
+        assertThat(result.getLimit()).isEqualTo(20);
+        assertThat(result.getTotal()).isZero();
+        assertThat(result.getHits()).isEmpty();
+    }
+
+    @Test
+    void searchShouldReturnEmptyResultWhenUnexpectedSearchErrorOccurs() throws Exception {
+        givenSuccessfulInitialization(meilisearchClient, index, taskInfo, "halo", 123);
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        when(index.search(any(SearchRequest.class))).thenThrow(new RuntimeException("boom"));
+        var engine = newEngine();
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+        var option = searchOption();
+
+        var result = engine.search(option);
+
+        assertThat(result.getKeyword()).isEqualTo("halo");
+        assertThat(result.getTotal()).isZero();
+        assertThat(result.getHits()).isEmpty();
+    }
+
+    @Test
+    void searchShouldRecoverSettingsAndRetryWhenSearchAttributesAreInvalid() throws Exception {
+        givenSuccessfulInitialization(meilisearchClient, index, taskInfo, "halo", 123);
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        when(index.search(any(SearchRequest.class)))
+            .thenThrow(new MeilisearchException("invalid_search_attributes_to_search_on"))
+            .thenReturn(searchResult);
+        when(searchResult.getEstimatedTotalHits()).thenReturn(1);
+        when(searchResult.getProcessingTimeMs()).thenReturn(7);
+        when(searchResult.getHits()).thenReturn(new ArrayList<>(List.of(hit())));
+        var engine = newEngine();
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+        var option = searchOption();
+
+        var result = engine.search(option);
+
+        assertThat(result.getTotal()).isEqualTo(1);
+        assertThat(result.getHits()).hasSize(1);
+        verify(index, times(2)).updateSearchableAttributesSettings(any(String[].class));
+        verify(index, times(2)).search(any(SearchRequest.class));
+        assertThat(engine.available()).isTrue();
+    }
+
+    @Test
+    void initializationShouldRetryWhenSettingsRemainInvalidAfterUpdate() throws Exception {
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        when(meilisearchClient.index("halo")).thenReturn(index);
+        when(meilisearchClient.getIndex("halo")).thenReturn(index);
+        givenSuccessfulSettingsUpdate(index, taskInfo, 123);
+        when(index.getSearchableAttributesSettings()).thenReturn(new String[]{});
+        doReturn(retryFuture)
+            .when(retryExecutor)
+            .schedule(any(Runnable.class), eq(5L), eq(TimeUnit.SECONDS));
+        var engine = newEngine();
+
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+
+        assertThat(engine.available()).isFalse();
+        verify(retryExecutor).schedule(any(Runnable.class), eq(5L), eq(TimeUnit.SECONDS));
+    }
+
+    @Test
+    void searchShouldBuildAllSupportedFilters() throws Exception {
+        givenSuccessfulInitialization(meilisearchClient, index, taskInfo, "halo", 123);
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        when(index.search(any(SearchRequest.class))).thenReturn(searchResult);
+        when(searchResult.getEstimatedTotalHits()).thenReturn(1);
+        when(searchResult.getProcessingTimeMs()).thenReturn(7);
+        when(searchResult.getHits()).thenReturn(new ArrayList<>(List.of(hit())));
+        var engine = newEngine();
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+        var option = searchOption();
+        option.setFilterPublished(true);
+        option.setFilterRecycled(false);
+        option.setFilterExposed(true);
+        option.setIncludeTypes(values("", "post.content.halo.run", "post.content.halo.run", null));
+        option.setIncludeOwnerNames(values(null, " admin ", " "));
+        option.setIncludeCategoryNames(values("category-a", "", null, "category-b"));
+        option.setIncludeTagNames(values("tag-a", "tag-a", null));
+
+        var result = engine.search(option);
+
+        assertThat(result.getTotal()).isEqualTo(1);
+        var requestCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+        verify(index).search(requestCaptor.capture());
+        assertThat(requestCaptor.getValue().getFilter())
+            .containsExactly("recycled = false AND exposed = true AND published = true"
+                + " AND (type = 'post.content.halo.run') AND (ownerName = 'admin')"
+                + " AND (tags = 'tag-a') AND (categories = 'category-a' AND categories = 'category-b')");
+    }
+
+    @Test
+    void searchShouldSkipNullAndMalformedHits() throws Exception {
+        givenSuccessfulInitialization(meilisearchClient, index, taskInfo, "halo", 123);
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        when(index.search(any(SearchRequest.class))).thenReturn(searchResult);
+        when(searchResult.getEstimatedTotalHits()).thenReturn(3);
+        when(searchResult.getProcessingTimeMs()).thenReturn(7);
+        var hits = new ArrayList<HashMap<String, Object>>();
+        hits.add(null);
+        hits.add(malformedHit());
+        hits.add(hit());
+        when(searchResult.getHits()).thenReturn(hits);
+        var engine = newEngine();
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+
+        var result = engine.search(searchOption());
+
+        assertThat(result.getTotal()).isEqualTo(3);
+        assertThat(result.getHits()).hasSize(1);
+        assertThat(result.getHits().getFirst().getMetadataName()).isEqualTo("post-name");
+    }
+
+    @Test
+    void addOrUpdateShouldStripHtmlBeforeIndexing() throws Exception {
+        givenSuccessfulInitialization(meilisearchClient, index, taskInfo, "halo", 123);
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        var engine = newEngine();
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+        var document = document();
+        document.setDescription("<p>Hello <strong>Halo</strong></p>");
+        document.setContent("<article>Search <em>content</em></article>");
+
+        engine.addOrUpdate(List.of(document));
+
+        var documentsCaptor = ArgumentCaptor.forClass(String.class);
+        verify(index).addDocuments(documentsCaptor.capture(), eq("id"));
+        assertThat(documentsCaptor.getValue()).contains("Hello Halo", "Search content");
+        assertThat(documentsCaptor.getValue()).doesNotContain("<p>", "<strong>", "<article>", "<em>");
+    }
+
+    @Test
+    void unavailableWriteOperationsShouldNotTouchMeilisearch() {
+        var engine = newEngine();
+
+        engine.addOrUpdate(List.of(document()));
+        engine.deleteDocument(List.of("post.content.halo.run-post-a"));
+        engine.deleteAll();
+
+        verifyNoInteractions(clientFactory, index);
+    }
+
+    @Test
+    void addOrUpdateShouldIgnoreMissingOrEmptyDocuments() throws Exception {
+        givenSuccessfulInitialization(meilisearchClient, index, taskInfo, "halo", 123);
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        var engine = newEngine();
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+
+        engine.addOrUpdate(null);
+        engine.addOrUpdate(List.of());
+        var documentsWithNull = new ArrayList<HaloDocument>();
+        documentsWithNull.add(null);
+        engine.addOrUpdate(documentsWithNull);
+
+        verify(index, never()).addDocuments(anyString(), eq("id"));
+    }
+
+    @Test
+    void deleteDocumentShouldUseHaloDocumentIds() throws Exception {
+        givenSuccessfulInitialization(meilisearchClient, index, taskInfo, "halo", 123);
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        var engine = newEngine();
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+
+        engine.deleteDocument(List.of(
+            "post.content.halo.run-post-name",
+            "singlepage.content.halo.run-page-name"
+        ));
+
+        verify(index).deleteDocuments(List.of(
+            "post.content.halo.run-post-name",
+            "singlepage.content.halo.run-page-name"
+        ));
+    }
+
+    @Test
+    void deleteDocumentShouldIgnoreMissingDocumentIds() throws Exception {
+        givenSuccessfulInitialization(meilisearchClient, index, taskInfo, "halo", 123);
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        var engine = newEngine();
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+
+        var docIds = new ArrayList<String>();
+        docIds.add(null);
+        docIds.add("");
+        docIds.add(" ");
+        engine.deleteDocument(docIds);
+
+        verify(index, never()).deleteDocuments(any());
+        verify(index, never()).deleteAllDocuments();
+    }
+
+    @Test
+    void deleteDocumentShouldDeleteAllWhenDocumentIdsAreMissing() throws Exception {
+        givenSuccessfulInitialization(meilisearchClient, index, taskInfo, "halo", 123);
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        var engine = newEngine();
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+
+        engine.deleteDocument(null);
+
+        verify(index).deleteAllDocuments();
+        verify(index, never()).deleteDocuments(any());
+    }
+
+    @Test
+    void deleteOperationsShouldSwallowMeilisearchExceptions() throws Exception {
+        givenSuccessfulInitialization(meilisearchClient, index, taskInfo, "halo", 123);
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        when(index.deleteDocuments(any())).thenThrow(new MeilisearchException("delete failed"));
+        when(index.deleteAllDocuments()).thenThrow(new MeilisearchException("delete all failed"));
+        var engine = newEngine();
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+
+        engine.deleteDocument(List.of("post.content.halo.run-post-name"));
+        engine.deleteAll();
+
+        assertThat(engine.available()).isTrue();
+    }
+
+    @Test
+    void initializationShouldCreateMissingIndexWithHaloDocumentIdPrimaryKey() throws Exception {
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        when(meilisearchClient.index("halo")).thenReturn(index);
+        when(meilisearchClient.getIndex("halo"))
+            .thenThrow(new MeilisearchException("index not found"));
+        when(meilisearchClient.createIndex("halo", "id")).thenReturn(createIndexTaskInfo);
+        when(createIndexTaskInfo.getTaskUid()).thenReturn(321);
+        givenSuccessfulSettingsInitialization(index, taskInfo, 123);
+        var engine = newEngine();
+        engine.onApplicationEvent(new PluginStartedEvent(this));
+
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+
+        assertThat(engine.available()).isTrue();
+        verify(meilisearchClient).waitForTask(321);
+        verify(eventPublisher).publishEvent(isA(HaloDocumentRebuildRequestEvent.class));
+    }
+
+    @Test
+    void initializationShouldRecreateLegacyMetadataNamePrimaryKeyIndex() throws Exception {
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        when(meilisearchClient.index("halo")).thenReturn(index, recreatedIndex);
+        when(meilisearchClient.getIndex("halo")).thenReturn(legacyIndex);
+        when(legacyIndex.getPrimaryKey()).thenReturn("metadataName");
+        when(meilisearchClient.deleteIndex("halo")).thenReturn(deleteIndexTaskInfo);
+        when(deleteIndexTaskInfo.getTaskUid()).thenReturn(111);
+        when(meilisearchClient.createIndex("halo", "id")).thenReturn(createIndexTaskInfo);
+        when(createIndexTaskInfo.getTaskUid()).thenReturn(222);
+        givenSuccessfulSettingsInitialization(recreatedIndex, taskInfo, 333);
+        var engine = newEngine();
+
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+
+        assertThat(engine.available()).isTrue();
+        verify(meilisearchClient).waitForTask(111);
+        verify(meilisearchClient).waitForTask(222);
+        verify(recreatedIndex, times(3)).waitForTask(333, 60_000, 100);
+        verify(eventPublisher, never()).publishEvent(isA(HaloDocumentRebuildRequestEvent.class));
+
+        engine.onApplicationEvent(new PluginStartedEvent(this));
+
+        verify(eventPublisher).publishEvent(isA(HaloDocumentRebuildRequestEvent.class));
+    }
+
+    private void givenSuccessfulInitialization(Client client, Index index, TaskInfo taskInfo,
+        String indexName, int taskUid) throws Exception {
+        when(client.index(indexName)).thenReturn(index);
+        when(client.getIndex(indexName)).thenReturn(index);
+        givenSuccessfulSettingsInitialization(index, taskInfo, taskUid);
+    }
+
+    private void givenSuccessfulSettingsInitialization(Index index, TaskInfo taskInfo, int taskUid)
+        throws Exception {
+        givenSuccessfulSettingsUpdate(index, taskInfo, taskUid);
+        when(index.getSearchableAttributesSettings()).thenReturn(SEARCH_ATTRIBUTES);
+        when(index.getFilterableAttributesSettings()).thenReturn(FILTERABLE_ATTRIBUTES);
+        when(index.getDisplayedAttributesSettings()).thenReturn(DISPLAYED_ATTRIBUTES);
+    }
+
+    private void givenSuccessfulSettingsUpdate(Index index, TaskInfo taskInfo, int taskUid)
+        throws Exception {
+        when(index.updateSearchableAttributesSettings(any(String[].class))).thenReturn(taskInfo);
+        when(index.updateFilterableAttributesSettings(any(String[].class))).thenReturn(taskInfo);
+        when(index.updateDisplayedAttributesSettings(any(String[].class))).thenReturn(taskInfo);
+        when(taskInfo.getTaskUid()).thenReturn(taskUid);
+    }
+
+    private MeilisearchSearchEngine newEngine() {
+        return new MeilisearchSearchEngine(extensionClient, eventPublisher, clientFactory,
+            retryExecutor);
+    }
+
+    private MeilisearchProperties properties() {
+        return properties("http://meilisearch:7700", "secret", "halo");
+    }
+
+    private MeilisearchProperties properties(String host, String masterKey, String indexName) {
+        var properties = new MeilisearchProperties();
+        properties.setHost(host);
+        properties.setMasterKey(masterKey);
+        properties.setIndexName(indexName);
+        return properties;
+    }
+
+    private SearchOption searchOption() {
+        var option = new SearchOption();
+        option.setKeyword("halo");
+        option.setLimit(20);
+        option.setHighlightPreTag("<mark>");
+        option.setHighlightPostTag("</mark>");
+        return option;
+    }
+
+    private List<String> values(String... values) {
+        var result = new ArrayList<String>();
+        for (var value : values) {
+            result.add(value);
+        }
+        return result;
+    }
+
+    private HashMap<String, Object> hit() {
+        var hit = new HashMap<String, Object>();
+        hit.put("id", "post.content.halo.run-post-name");
+        hit.put("metadataName", "post-name");
+        hit.put("title", "Halo");
+        hit.put("content", "Search content");
+        hit.put("description", "Description");
+        hit.put("published", true);
+        hit.put("recycled", false);
+        hit.put("exposed", true);
+        hit.put("ownerName", "admin");
+        hit.put("permalink", "/archives/post-name");
+        hit.put("type", "post.content.halo.run");
+        return hit;
+    }
+
+    private HashMap<String, Object> malformedHit() {
+        return new HashMap<>() {
+            @Override
+            public Object get(Object key) {
+                throw new IllegalArgumentException("malformed hit");
+            }
+        };
+    }
+
+    private HaloDocument document() {
+        var document = new HaloDocument();
+        document.setId("post.content.halo.run-post-name");
+        document.setMetadataName("post-name");
+        document.setTitle("Halo");
+        document.setContent("Search content");
+        document.setDescription("Description");
+        document.setPublished(true);
+        document.setRecycled(false);
+        document.setExposed(true);
+        document.setOwnerName("admin");
+        document.setPermalink("/archives/post-name");
+        document.setType("post.content.halo.run");
+        return document;
+    }
+}

--- a/src/test/java/run/halo/meilisearch/MeilisearchSearchEngineTest.java
+++ b/src/test/java/run/halo/meilisearch/MeilisearchSearchEngineTest.java
@@ -1,6 +1,7 @@
 package run.halo.meilisearch;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -19,6 +20,7 @@ import com.meilisearch.sdk.Config;
 import com.meilisearch.sdk.Index;
 import com.meilisearch.sdk.SearchRequest;
 import com.meilisearch.sdk.exceptions.MeilisearchException;
+import com.meilisearch.sdk.model.IndexStats;
 import com.meilisearch.sdk.model.SearchResult;
 import com.meilisearch.sdk.model.Settings;
 import com.meilisearch.sdk.model.Task;
@@ -118,6 +120,9 @@ class MeilisearchSearchEngineTest {
 
     @Mock
     SearchResult searchResult;
+
+    @Mock
+    IndexStats indexStats;
 
     @Mock
     TaskInfo documentTaskInfo;
@@ -670,7 +675,6 @@ class MeilisearchSearchEngineTest {
         engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
 
         assertThat(engine.available()).isTrue();
-        verify(meilisearchClient).waitForTask(321);
         verify(meilisearchClient).getTask(321);
         verify(eventPublisher).publishEvent(isA(HaloDocumentRebuildRequestEvent.class));
     }
@@ -691,9 +695,7 @@ class MeilisearchSearchEngineTest {
         engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
 
         assertThat(engine.available()).isTrue();
-        verify(meilisearchClient).waitForTask(111);
         verify(meilisearchClient).getTask(111);
-        verify(meilisearchClient).waitForTask(222);
         verify(meilisearchClient).getTask(222);
         verify(recreatedIndex).waitForTask(333, 60_000, 100);
         verify(eventPublisher, never()).publishEvent(isA(HaloDocumentRebuildRequestEvent.class));
@@ -721,7 +723,6 @@ class MeilisearchSearchEngineTest {
         engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
 
         assertThat(engine.available()).isFalse();
-        verify(meilisearchClient).waitForTask(321);
         verify(meilisearchClient).getTask(321);
         verify(index, never()).updateSettings(any(Settings.class));
         verify(retryExecutor).schedule(any(Runnable.class), eq(5L), eq(TimeUnit.SECONDS));
@@ -745,11 +746,33 @@ class MeilisearchSearchEngineTest {
         engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
 
         assertThat(engine.available()).isFalse();
-        verify(meilisearchClient).waitForTask(111);
         verify(meilisearchClient).getTask(111);
         verify(meilisearchClient, never()).createIndex("halo", "meilisearchId");
         verify(index, never()).updateSettings(any(Settings.class));
         verify(retryExecutor).schedule(any(Runnable.class), eq(5L), eq(TimeUnit.SECONDS));
+    }
+
+    @Test
+    void getStatsShouldUseCurrentIndex() throws Exception {
+        givenSuccessfulInitialization(meilisearchClient, index, taskInfo, "halo", 123);
+        when(clientFactory.create(any(Config.class))).thenReturn(meilisearchClient);
+        when(index.getStats()).thenReturn(indexStats);
+        var engine = newEngine();
+        engine.onApplicationEvent(new ConfigUpdatedEvent(this, properties()));
+
+        var stats = engine.getStats();
+
+        assertThat(stats).isSameAs(indexStats);
+        verify(index).getStats();
+    }
+
+    @Test
+    void getStatsShouldFailWhenEngineIsUnavailable() {
+        var engine = newEngine();
+
+        assertThatThrownBy(engine::getStats)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Meilisearch is not available");
     }
 
     private void givenSuccessfulInitialization(Client client, Index index, TaskInfo taskInfo,


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` with repository agent instructions.
- Align Meilisearch document identity with Halo native Lucene search by using `HaloDocument.id` as the primary key.
- Recreate legacy Meilisearch indexes that still use `metadataName` as the primary key, then request a rebuild after the plugin is fully started.
- Ignore unrelated or incomplete ConfigMap reconciliation events so startup/default settings cannot overwrite a working Meilisearch client with an unavailable state.
- Apply Meilisearch searchable/filterable/displayed settings through dedicated settings APIs, verify them after task completion, and recover/retry once when search reports invalid searchable attributes.
- Harden indexing, deletion, settings initialization, retry, and malformed search-result handling so Meilisearch outages or bad payloads do not break search calls.
- Add unit coverage for configuration changes, retries, primary-key migration, plugin-start rebuild deferral, settings validation/recovery, null/empty events, malformed hits, and failure paths.

## Related issues

- halo-dev/halo#8174
- halo-sigs/plugin-meilisearch#7

## Validation

- `./gradlew test`
- `./gradlew build`
- `git diff --check`
- Java tests: `44` tests, `0` failures, `0` errors, `0` skipped